### PR TITLE
feat: 게시글 상세 조회 시 조회수를 1회 증가하는 전역 훅 추가

### DIFF
--- a/BackendServer/package-lock.json
+++ b/BackendServer/package-lock.json
@@ -13582,6 +13582,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
       "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
       "dependencies": {
         "passport-oauth2": "1.x.x"
       },

--- a/BackendServer/src/app.module.ts
+++ b/BackendServer/src/app.module.ts
@@ -22,6 +22,7 @@ import { EnsembleModule } from './ensemble/ensemble.module';
 import { MailerModule } from '@nestjs-modules/mailer';
 import { LocationModule } from './map/location.module';
 import { ApplicationModule } from './application/application.module';
+import { ViewCountModule } from './hooks/view_count/view-count.module';
 
 @Module({
   imports: [
@@ -76,6 +77,7 @@ import { ApplicationModule } from './application/application.module';
     EnsembleModule,
     LocationModule,
     ApplicationModule,
+    ViewCountModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BackendServer/src/ensemble/ensemble.module.ts
+++ b/BackendServer/src/ensemble/ensemble.module.ts
@@ -9,5 +9,6 @@ import { SessionEnsemble } from './session/entities/session-ensemble.entity';
   imports: [TypeOrmModule.forFeature([RecruitEnsemble, SessionEnsemble])],
   controllers: [EnsembleController],
   providers: [EnsembleService],
+  exports: [EnsembleService],
 })
 export class EnsembleModule {}

--- a/BackendServer/src/ensemble/ensemble.service.ts
+++ b/BackendServer/src/ensemble/ensemble.service.ts
@@ -276,4 +276,8 @@ export class EnsembleService {
     const updatedSession = this.sessionEnsembleRepo.merge(session, updateDto);
     return this.sessionEnsembleRepo.save(updatedSession);
   }
+
+  async incrementViewCount(id: number): Promise<void> {
+    await this.recruitEnsembleRepo.increment({ postId: id }, 'viewCount', 1);
+  }
 }

--- a/BackendServer/src/hooks/view_count/view-count.controller.ts
+++ b/BackendServer/src/hooks/view_count/view-count.controller.ts
@@ -1,0 +1,25 @@
+import {
+  Controller,
+  Post,
+  Param,
+  BadRequestException
+} from '@nestjs/common';
+import { ViewCountableType, ViewCountService } from './view-count.service';
+
+@Controller('/api/count-view')
+export class ViewCountController {
+  constructor(private readonly viewCountService: ViewCountService) {}
+
+  @Post(':type/:id')
+  async countView(
+    @Param('type') type: ViewCountableType,
+    @Param('id') id: string,
+  ) {
+    const idNumber = Number(id);
+    if(isNaN(idNumber)){
+      throw new BadRequestException('Invalid ID');
+    }
+    console.log(`View count incremented for type=${type}, id=${id}`);
+    return this.viewCountService.countView(type as ViewCountableType, idNumber);
+  }
+}

--- a/BackendServer/src/hooks/view_count/view-count.module.ts
+++ b/BackendServer/src/hooks/view_count/view-count.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { ViewCountController } from "./view-count.controller";
+import { ViewCountService } from "./view-count.service";
+import { EnsembleModule } from "src/ensemble/ensemble.module";
+import { UsedProductModule } from "src/used_product/used-product.module";
+import { PracticeRoomModule } from "src/practice_room/practice-room.module";
+
+@Module({
+  imports: [EnsembleModule, UsedProductModule, PracticeRoomModule],
+  controllers: [ViewCountController],
+  providers: [ViewCountService],
+})
+
+export class ViewCountModule {}

--- a/BackendServer/src/hooks/view_count/view-count.service.ts
+++ b/BackendServer/src/hooks/view_count/view-count.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, BadRequestException, Inject } from "@nestjs/common";
+import { EnsembleService } from "src/ensemble/ensemble.service";
+import { PracticeRoomService } from "src/practice_room/practice-room.service";
+import { UsedProductService } from "src/used_product/used-product.service";
+
+export type ViewCountableType = 'practice-room' | 'used-products' | 'ensembles' ;
+
+@Injectable()
+export class ViewCountService {
+  constructor(
+    private readonly ensembleService: EnsembleService,
+    private readonly practiceRoomService: PracticeRoomService,
+    private readonly usedProductService: UsedProductService
+  ) {}
+
+  async countView (type: ViewCountableType, id: number) {
+    switch(type){
+      case 'ensembles':
+        return this.ensembleService.incrementViewCount(id);
+      case 'practice-room':
+        return this.practiceRoomService.incrementViewCount(id);
+      case 'used-products':
+        return this.usedProductService.incrementViewCount(id);
+      default:
+        throw new BadRequestException('Unknow content type');
+    }
+  }
+}

--- a/BackendServer/src/practice_room/practice-room.service.ts
+++ b/BackendServer/src/practice_room/practice-room.service.ts
@@ -106,4 +106,8 @@ export class PracticeRoomService{
     const updatedPost = this.practiceRoomRepo.merge(post, updateDto);
     return this.practiceRoomRepo.save(updatedPost);
   }
+
+  async incrementViewCount(id: number): Promise<void> {
+    await this.practiceRoomRepo.increment({ postId: id }, 'viewCount', 1);
+  }
 }

--- a/BackendServer/src/used_product/used-product.service.ts
+++ b/BackendServer/src/used_product/used-product.service.ts
@@ -164,4 +164,8 @@ export class UsedProductService {
     
     return results.map(row => row.locationId);
   }
+
+  async incrementViewCount(id: number): Promise<void> {
+    await this.usedProductRepo.increment({ productId: id }, 'viewCount', 1);
+  }
 }

--- a/WebFrontend/package-lock.json
+++ b/WebFrontend/package-lock.json
@@ -2301,6 +2301,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
       "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }

--- a/WebFrontend/src/hooks/useViewCounter.ts
+++ b/WebFrontend/src/hooks/useViewCounter.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import axiosInstance from "@/services/axiosInstance";
+
+// 조회수 증가가 필요한 페이지에서 아래처럼 호출하세요.
+// useViewCounter({ type: 'practice-room' }); // 연습실 상세 페이지용
+export type ViewCountableType = 'practice-room' | 'used-products' | 'ensembles' ;
+
+interface useViewCounterOptions {
+  type: ViewCountableType;
+}
+
+const useViewCounter = ({ type }: useViewCounterOptions) => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const match = location.pathname.match(/\/[^/]+\/(\d+)/);
+    const id = match?.[1];
+
+    if(!id) return;
+
+    // local storage 기반으로 유저 1명에 대해 조회수 1 증가
+    const storageKey = `${type}-${id}-viewed`;
+    const hasViewed = localStorage.getItem(storageKey);
+
+    if(hasViewed) return;
+
+    console.log('[ViewCountController] HIT', type, id);
+    console.log(`[ViewCounter] Sending view count request for ${type}/${id}`);
+
+    axiosInstance
+      .post(`/api/count-view/${type}/${id}`)
+      .then(() => {
+        localStorage.setItem(storageKey, 'true');
+      })
+      .catch(console.error);
+  }, [location.pathname, type])
+};
+
+export default useViewCounter;

--- a/WebFrontend/src/pages/ensemble/RecruitEnsembleDetailPage.tsx
+++ b/WebFrontend/src/pages/ensemble/RecruitEnsembleDetailPage.tsx
@@ -7,6 +7,7 @@ import axiosInstance from '@/services/axiosInstance';
 import axios from 'axios';
 import type { SessionEnsemble, RecruitEnsemble, ApplicationEnsemble } from './types';
 import { SessionDetail } from './components/SessionDetail';
+import useViewCounter from '@/hooks/useViewCounter';
 
 // 목록 페이지에서 사용했던 타입과 텍스트 매핑 객체를 가져옵니다.
 // 별도 types 파일로 분리하여 관리하는 것이 좋습니다.
@@ -17,6 +18,7 @@ const RecruitEnsembleDetailPage: React.FC = () => {
   // URL 파라미터에서 게시글 ID를 가져옵니다.
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  useViewCounter({ type: 'ensembles' });
 
   const [sessionList, setSessionList] = useState<SessionEnsemble[] | null>(null);
   const [ensemble, setEnsemble] = useState<RecruitEnsemble | null>(null);

--- a/WebFrontend/src/pages/practiceRoom/PracticeRoomDetailPage.tsx
+++ b/WebFrontend/src/pages/practiceRoom/PracticeRoomDetailPage.tsx
@@ -4,6 +4,7 @@ import axiosInstance from '@/services/axiosInstance';
 import { type PracticeRoom } from '@/types/practiceRoom';
 import { useAuthStore } from '@/stores/authStore';
 import { PracticeRoomDetail } from '@/components/layout/pages/practiceRoom/PracticeRoomDetailForm';
+import useViewCounter from '@/hooks/useViewCounter';
 
 const PracticeRoomDetailPage: React.FC = () => 
 {
@@ -15,6 +16,8 @@ const PracticeRoomDetailPage: React.FC = () =>
   const [error, setError] = useState<string | null>(null);
 
   const isOwner = Boolean(post && user && post.userId === user.userId);
+
+  useViewCounter({ type: 'practice-room' });
 
   useEffect (() => {
     if(!id){

--- a/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { type UsedProduct, STATUS, TRADE_TYPE } from '../../types/product';
 import { useAuthStore } from '@/stores/authStore';
 import axiosInstance from '@/services/axiosInstance';
+import useViewCounter from '@/hooks/useViewCounter';
 
 // CSS 파일을 import 하던 코드는 삭제합니다.
 
@@ -36,6 +37,8 @@ const UsedProductDetailPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const isOwner = (product && user && product.userId === user.userId)
+
+  useViewCounter({ type: 'used-products' });
 
   useEffect(() => {
     if (!id) {

--- a/WebFrontend/src/types/practiceRoom.ts
+++ b/WebFrontend/src/types/practiceRoom.ts
@@ -10,7 +10,7 @@ export interface Location {
 // -- DB에 저장된 상품 데이터의 완전한 형태 -- 
 export interface PracticeRoom {
   readonly postId: number;
-  readonly userId: number;
+  readonly userId: string;
   user_name: string;
   title: string;
   description: string;


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [ ] FE 훅(useViewCounter)을 통해 상세 페이지 진입 시 조회수 증가 API 호출
- [ ] 조회수는 localStorage 기반으로 사용자당 1회만 증가
- [ ] 영향받은 게시판: 중고장터, 합주실 예약, 합주 인원 모집


## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 
2. 
3. 


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.