### PR TITLE
feat: 악기거래 게시판의 필터 BE 구현

### DIFF
--- a/BackendServer/src/used_product/dto/pagination-query-used-product.dto.ts
+++ b/BackendServer/src/used_product/dto/pagination-query-used-product.dto.ts
@@ -19,4 +19,9 @@ export class PaginationQueryUsedProductDto {
   @Type(() => Date)
   @IsDate()
   lastCreatedAt?: Date; // <<< last_create_at -> lastCreatedAt (camelCase로 변경)
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  categoryId?: number;
 }

--- a/BackendServer/src/used_product/entities/used-product.entity.ts
+++ b/BackendServer/src/used_product/entities/used-product.entity.ts
@@ -12,15 +12,15 @@ import { Location } from 'src/map/entities/location.entity';
 
 // 👇 STATUS Enum에 문자열 값을 할당합니다.
 export enum STATUS {
-  FOR_SALE,
-  IN_PROGRESS,
-  SOLD,
+  FOR_SALE = 'FOR_SALE',
+  IN_PROGRESS = 'IN_PROGRESS',
+  SOLD = 'SOLD',
 }
 
 // 👇 TRADE_TYPE Enum에 문자열 값을 할당합니다.
 export enum TRADE_TYPE {
-  IN_PERSON,
-  DELIVERY,
+  IN_PERSON = 'IN_PERSON',
+  DELIVERY = 'DELIVERY',
 }
 
 @Entity({ name: 'used_products' })

--- a/BackendServer/src/used_product/used-product.controller.ts
+++ b/BackendServer/src/used_product/used-product.controller.ts
@@ -18,7 +18,7 @@ import { UsedProductService } from './used-product.service';
 import { CreateUsedProductDto } from './dto/create-used-product.dto';
 import { PaginationQueryUsedProductDto } from './dto/pagination-query-used-product.dto';
 import { UpdateUsedProductDto } from './dto/update-used-product.dto';
-import { UsedProduct } from './entities/used-product.entity';
+import { UsedProduct, STATUS as Status } from './entities/used-product.entity';
 import { PaginatedUsedProductResponse } from './dto/paginated-used-product.response.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
@@ -35,12 +35,13 @@ export class UsedProductController {
     this.logger.log('Fetching used products with pagination');
 
     // <<< DTO의 변수명 변경에 맞춰 수정하고, limit 기본값 설정
-    const { limit = 20, lastProductId, lastCreatedAt } = paginationQuery;
+    const { limit = 20, lastProductId, lastCreatedAt, categoryId } = paginationQuery;
 
     return this.usedProductService.findUsedProductWithPagination(
       limit,
       lastProductId,
       lastCreatedAt,
+      categoryId,
     );
   }
 
@@ -117,5 +118,22 @@ export class UsedProductController {
       updateUsedProductDto,
       id,
     );
+  }
+
+  @Patch(':id/status')
+  @UseGuards(AuthGuard('jwt'))
+  async updateSalesStatus(
+    @Param('id', ParseIntPipe) productId: number,
+    @Body('status') status: Status,
+    @Req() req: Request,
+  ): Promise<UsedProduct> {
+    if (!req.user || !req.user.id) {
+      this.logger.error(
+        'Authentication information missing from request user object.',
+      );
+      throw new ForbiddenException('사용자 인증 정보가 없습니다.');
+    }
+    const id = req.user.id;
+    return this.usedProductService.updateSalesStatus(productId, id, status);
   }
 }

--- a/BackendServer/src/used_product/used-product.module.ts
+++ b/BackendServer/src/used_product/used-product.module.ts
@@ -6,11 +6,12 @@ import { UsedProduct } from './entities/used-product.entity';
 import { LocationModule } from 'src/map/location.module';
 import { Location } from '../map/entities/location.entity';
 import { ImageModule } from 'src/image/image.module';
+import { Image } from 'src/image/entities/image.entity';
 
 // -- location import 추가합니다 --
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UsedProduct, Location]),
+    TypeOrmModule.forFeature([UsedProduct, Location, Image]),
     forwardRef(() => LocationModule),
     ImageModule,
   ],

--- a/BackendServer/src/used_product/used-product.service.ts
+++ b/BackendServer/src/used_product/used-product.service.ts
@@ -11,6 +11,7 @@ import { UpdateUsedProductDto } from './dto/update-used-product.dto';
 import { PaginatedUsedProductResponse } from './dto/paginated-used-product.response.dto';
 import { Location } from 'src/map/entities/location.entity';
 import { ImageService } from 'src/image/image.service';
+import { Image } from 'src/image/entities/image.entity';
 
 
 @Injectable()
@@ -22,6 +23,8 @@ export class UsedProductService {
     @InjectRepository(Location)
     private readonly locationRepo: Repository<Location>,
     
+    @InjectRepository(Image)
+    private readonly imageRepo : Repository<Image>,
     private readonly imageService: ImageService,
   ) {}
 
@@ -29,6 +32,7 @@ export class UsedProductService {
     limit: number,
     lastProductId?: number,
     lastCreatedAt?: Date,
+    categoryId?: number,
   ): Promise<PaginatedUsedProductResponse> {
     const realLimit = limit + 1;
     const queryBuilder = this.usedProductRepo.createQueryBuilder('usedProduct');
@@ -39,6 +43,10 @@ export class UsedProductService {
         '(usedProduct.createdAt < :lastCreatedAtDate) OR (usedProduct.createdAt = :lastCreatedAtDate AND usedProduct.productId < :lastProductId)',
         { lastCreatedAtDate, lastProductId },
       );
+    }
+
+    if(categoryId) {
+      queryBuilder.andWhere('usedProduct.categoryId = :categoryId', { categoryId });
     }
 
     const results = await queryBuilder
@@ -59,8 +67,34 @@ export class UsedProductService {
           }
         : undefined;
 
+    // 대표 이미지 추출
+    const productIds = data.map((p) => p.productId);
+
+    // 참조하는 이미지가 없는 경우를 아래 쿼리를 실행하지 않음
+    if (productIds.length === 0) return { data: [], nextCursor, hasNextPage };
+
+    const thumbnails = await this.imageRepo
+      .createQueryBuilder('image')
+      .where('image.refPostId IN (:...productIds)', { productIds })
+      .andWhere('image.uploadOrder = 0')
+      .getMany();
+
+    const imageMap = new Map<number, string>();
+    thumbnails.forEach((img) => {
+      if(img.refPostId !== null && !imageMap.has(img.refPostId)){
+        imageMap.set(Number(img.refPostId), img.imageUrl);
+      }
+    });
+
+    const dataWithThumbnails = data.map((product) => ({
+      ...product,
+      imageUrl: imageMap.get(product.productId) || null,
+    }));
+
+    // console.log('[쿼리 결과 Datawiththumbnails]', dataWithThumbnails);
+
     return {
-      data,
+      data: dataWithThumbnails,
       nextCursor,
       hasNextPage,
     };
@@ -204,5 +238,14 @@ export class UsedProductService {
 
   async incrementViewCount(id: number): Promise<void> {
     await this.usedProductRepo.increment({ productId: id }, 'viewCount', 1);
+  }
+
+  async updateSalesStatus(productId: number, id: string, status: Status) {
+    const product = await this.usedProductRepo.findOneBy({ productId: productId });
+    if (!product) throw new NotFoundException(`Product with ID #${productId} not found.`);
+    if (id !== product.id) throw new ForbiddenException(`Unauthorized`);
+
+    product.status = status;
+    return this.usedProductRepo.save(product);
   }
 }

--- a/WebFrontend/src/components/atoms/button/StatusToastMenu.tsx
+++ b/WebFrontend/src/components/atoms/button/StatusToastMenu.tsx
@@ -1,0 +1,68 @@
+import toast from 'react-hot-toast';
+import Icon from '@/components/atoms/icon/Icon';
+import { STATUS, STATUS_TEXT } from '@/types/product';
+
+
+export const StatusToastMenu = ({
+  onChangeStatus,
+  onClose,
+  currentStatus,
+}: {
+  onChangeStatus: (status: STATUS) => void;
+  onClose?: () => void;
+  currentStatus: STATUS;
+}) => {
+  toast.custom((t) => (
+    <div
+      className={`
+        fixed bottom-0 left-1/2 -translate-x-1/2
+        w-full max-w-[430px] mx-auto
+        rounded-t-[30px] bg-white p-4 shadow-md
+        transition-all duration-300 ease-in-out
+        pointer-events-auto
+        ${t.visible ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'}
+      `}
+    >
+      <div className="w-12 h-1 bg-brand-disabled rounded-full mx-auto mt-1 mb-4 opacity-70" />
+      <div className="bg-brand-frame rounded-xl mt-[40px]">
+        {Object.entries(STATUS).map(([key, value]) => {
+          const isDisabled = currentStatus === 'SOLD';
+
+          return (
+            <div key={key} className="flex items-center justify-center gap-2 py-3">
+              <Icon name="check" size={20} className="text-brand-gray" />
+                <button
+                type="button"
+                className="text-caption text-brand-gray"
+                disabled={isDisabled}
+                onClick={() => {
+                  if (value === 'SOLD') {
+                  const confirmed = window.confirm('한 번 판매완료로 변경하면 되돌릴 수 없습니다. 진행할까요?');
+                  if (!confirmed) return;
+                  }
+                  // 상태 변경
+                  onChangeStatus(value as STATUS);
+                  toast.dismiss(t.id);
+                  onClose?.();
+                }}
+                >
+                {STATUS_TEXT[value as STATUS]}
+                </button>
+          </div>
+          )
+        })}
+        <div className="flex items-start justify-center gap-2 py-3">
+          <button
+            className="text-caption text-brand-gray"
+            onClick={() => toast.dismiss(t.id)}
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  ), {
+    duration: Infinity,     // 토스트 팝업 지속 시간
+    position: 'bottom-center',
+  });
+};

--- a/WebFrontend/src/components/atoms/card/UserProfileCard.tsx
+++ b/WebFrontend/src/components/atoms/card/UserProfileCard.tsx
@@ -7,6 +7,7 @@ interface UserProfileCardProps {
   location: string;
   status?: "판매중" | "예약중" | "판매완료";
   statusSlot?: React.ReactNode;   // 상태바 대신 버튼 같은 컴포넌트를 받을 수 있음
+  onClick?: () => void;
 }
 
 export const baseStatusStyle = "rounded-[10px] px-4 py-1 text-[14px] whitespace-nowrap";
@@ -47,6 +48,7 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({
   location,
   status,
   statusSlot,
+  onClick,
 }) => {
   const style = status ? statusStyleMap[status] : { bg: "", text: "", hover: "" };
   
@@ -65,15 +67,16 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({
           <p className="text-sm text-left text-gray-500">{location}</p>
         </div>
       </div>
-      { statusSlot ? (
+      { statusSlot !== undefined ? (
         <>{statusSlot}</>
-      ) : (
-        <span
+      ) : status ? (
+        <button
         className={`${baseStatusStyle} ${style.bg ?? ""} ${style.text ?? ""} ${'hover' in style ? style.hover : ""}`}
+        onClick={onClick}
         >
           {status}
-        </span>
-      )}
+        </button>
+      ) : null }
     </div>
   );
 };

--- a/WebFrontend/src/components/atoms/icon/Icon.tsx
+++ b/WebFrontend/src/components/atoms/icon/Icon.tsx
@@ -41,6 +41,7 @@ import {
   IoLocationSharp,
   IoHeart,
   IoOptionsOutline,
+  IoChevronDownOutline,
 } from 'react-icons/io5';
 
 // 아이콘 이름을 키로, 실제 컴포넌트를 값으로 매핑합니다.
@@ -84,6 +85,7 @@ const iconMap = {
   camera: IoCameraOutline, // 카메라
   mapPin: IoLocationSharp, // 지도 핀
   options: IoOptionsOutline,
+  downArrow: IoChevronDownOutline,   // 드롭다운용 다운
 };
 
 // Icon 컴포넌트가 받을 props 타입을 정의합니다.

--- a/WebFrontend/src/components/atoms/input/CategorySelector.tsx
+++ b/WebFrontend/src/components/atoms/input/CategorySelector.tsx
@@ -1,19 +1,15 @@
 import React from "react";
-
-export interface CategoryOption {
-  id: string;
-  name: string;
-}
+import Icon from '@/components/atoms/icon/Icon';
 
 interface CategoryProps {
   name: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-  categories: CategoryOption[];
+  categories: { id: number | string; name: string }[];
   showSubCategory?: boolean;
 }
 
-const inputStyles = "w-full py-3 px-4 bg-brand-inverse border border-gray-300 rounded-md box-border text-caption placeholder:text-gray-400 focus:border-[var(--color-brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-brand-primary)]";
+const inputStyles = "w-full py-3 px-4 bg-brand-inverse border border-gray-300 rounded-[var(--radius-card)] box-border text-caption placeholder:text-gray-400 focus:border-[var(--color-brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-brand-primary)] appearance-none";
 
 
 const CategorySelector: React.FC<CategoryProps> = ({
@@ -25,7 +21,7 @@ const CategorySelector: React.FC<CategoryProps> = ({
   return (
     <div className="mb-6 flex items-center justify-between gap-2">
       {/* 대분류 */}
-      <div className="flex-1">
+      <div className="relative flex-1">
         <select
           id="categoryId"
           name="categoryId"
@@ -40,13 +36,17 @@ const CategorySelector: React.FC<CategoryProps> = ({
             </option>
           ))}
         </select>
+        {/* 기본 select 화살표를 숨기고, 커스텀 아이콘을 우측에 배치합니다 */}
+        <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2">
+          <Icon name="downArrow" className="w-4 h-4 text-gray-500" />
+        </div>
       </div>
 
       {showSubCategory && (
         <>
           <span className="text-xl text-gray-700">›</span>
           {/* 중분류 */}
-          <div className="flex-1">
+          <div className="relative flex-1">
             <select
               id="subCategory"
               name="subCategory"
@@ -55,6 +55,9 @@ const CategorySelector: React.FC<CategoryProps> = ({
             >
               <option value="">선택</option>
             </select>
+            <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2">
+              <Icon name="downArrow" className="w-4 h-4 text-gray-500" />
+            </div>
           </div>
         </>
       )}

--- a/WebFrontend/src/components/layout/CategoryList.tsx
+++ b/WebFrontend/src/components/layout/CategoryList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { PRODUCT_CATEGORY_LABELS } from "@/types/product";
 
 interface CategoryListProps {
   categories?: string[];
@@ -6,19 +7,19 @@ interface CategoryListProps {
   selectedCategory?: string;
 }
 
-const defaultCategories = ['전체', '일렉', '베이스', '통기타', '클래식'];
+const productCategories = ["전체", ...Object.values(PRODUCT_CATEGORY_LABELS)];
 
 const CategoryList: React.FC<CategoryListProps> = ({
-  categories = defaultCategories,
+  categories = productCategories,
   onClickCategory,
   selectedCategory,
 }) => {
   const categoryImages: Record<string, string> = {
-    전체: 'https://placehold.co/60x60?text=All',
-    일렉: 'https://placehold.co/60x60?text=Electic',
-    베이스: 'https://placehold.co/64x64?text=Base',
-    통기타: 'https://placehold.co/64x64?text=Acoustic',
-    클래식: 'https://placehold.co/64x64?text=Classic',
+    전체: 'https://recho-img.s3.ap-northeast-2.amazonaws.com/default-img/all.jpg',
+    일렉기타: 'https://recho-img.s3.ap-northeast-2.amazonaws.com/default-img/electric.png',
+    베이스기타: 'https://recho-img.s3.ap-northeast-2.amazonaws.com/default-img/base.png', // public 폴더에 파일을 두고 이렇게 경로 지정
+    통기타: 'https://recho-img.s3.ap-northeast-2.amazonaws.com/default-img/acoustic.png',
+    클래식기타: 'https://recho-img.s3.ap-northeast-2.amazonaws.com/default-img/classical.png',
   };
 
   return (
@@ -30,15 +31,17 @@ const CategoryList: React.FC<CategoryListProps> = ({
             onClick={() => onClickCategory?.(category)}
             className="flex flex-col items-center flex-shrink-0 cursor-pointer"
           >
-            <img
-              src={categoryImages[category] || 'https://placehold.co/64x64?text=기타'}
-              alt={category}
-              className={`w-[64px] h-[64px] rounded-full transition-all duration-100 ease-in-out ${
-                selectedCategory === category
-                  ? "ring-1 ring-brand-primary"
-                  : "bg-gray-200 opacity-80"
-              }`}
-            />
+            <div className="w-[64px] h-[64px]">
+              <img
+                src={categoryImages[category] || 'https://placehold.co/64x64?text=기타'}
+                alt={category}
+                className={`w-full h-full object-cover bg-white rounded-full transition-all duration-100 ease-in-out ${
+                  selectedCategory === category
+                    ? "ring-1 ring-brand-primary"
+                    : "bg-white opacity-80"
+                }`}
+              />
+            </div>
             <span className="mt-1 text-[14px] text-black">{category}</span>
           </div>
         ))}

--- a/WebFrontend/src/components/layout/pages/usedProduct/ProductForm.tsx
+++ b/WebFrontend/src/components/layout/pages/usedProduct/ProductForm.tsx
@@ -1,23 +1,21 @@
 // src/components/ProductForm.tsx (새로 생성)
 
 import React from 'react';
-import { useState } from 'react';
 import { type UsedProductForm } from '../../../../types/product'
 import LocationSelector from '../../../map/LocationSelector';
 import InputLabel from '@/components/atoms/input/InputLabel';
 import CategorySelector from '@/components/atoms/input/CategorySelector';
+import { PRODUCT_CATEGORY_LABELS } from '@/types/product';
 import TextInputForm from '@/components/atoms/input/TextInputForm';
 import TextAreaInput from '@/components/atoms/input/TextAreaInput';
 import PrimaryButton from '@/components/atoms/button/PrimaryButton';
 import ImageUploadPreview from '@/components/atoms/input/ImageUploadPreveiw';
 
 
-const productCategories = [
-  { id: '1', name: '베이스기타' },
-  { id: '2', name: '일렉기타' },
-  { id: '3', name: '클래식기타' },
-  { id: '4', name: '통기타' },
-];
+const categoryLabels = Object.entries(PRODUCT_CATEGORY_LABELS).map(([key, name]: [string, string]) => ({
+  id: Number(key), // ProductCategory
+  name,
+}));
 
 const tradeCategories = [
   { id: 'IN_PERSON', name: '직거래' },
@@ -28,6 +26,8 @@ const tradeCategories = [
 interface ProductFormProps {
   formState: UsedProductForm;
   onFormChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
+  onCategoryChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onTradeTypeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   isLoading: boolean;
   errorMessage: string | null;
@@ -41,6 +41,8 @@ interface ProductFormProps {
 export const ProductForm: React.FC<ProductFormProps> = ({
   formState,
   onFormChange,
+  onCategoryChange,
+  onTradeTypeChange,
   onFormSubmit,
   isLoading,
   errorMessage,
@@ -50,9 +52,6 @@ export const ProductForm: React.FC<ProductFormProps> = ({
   originalImages = [],
   onImageChange,
 }) => {
-  const [form1, setForm1] = useState({ categoryId: '' });
-  const [form2, setForm2] = useState({ TRADE_TYPE: '' });
-
   return (
     <form onSubmit={onFormSubmit}>
       <div className="mb-6">
@@ -84,9 +83,11 @@ export const ProductForm: React.FC<ProductFormProps> = ({
         <InputLabel htmlFor="categoryId">카테고리</InputLabel>
         <CategorySelector
           name="productCategories"
-          value={String(form1.categoryId)}
-          onChange={(e) => setForm1({ categoryId: e.target.value })}
-          categories={productCategories}
+          // value={String(form1.categoryId)}
+          // onChange={(e) => setForm1({ categoryId: e.target.value })}
+          value={String(formState.categoryId)}
+          onChange={onCategoryChange}
+          categories={categoryLabels}
           showSubCategory={true}
         />
       </div>
@@ -108,9 +109,10 @@ export const ProductForm: React.FC<ProductFormProps> = ({
       <div className="mb-6">
         <InputLabel htmlFor="tradeType">거래 방식</InputLabel>
         <CategorySelector
-          name="tradeCategories"
-          value={String(form2.TRADE_TYPE)}
-          onChange={(e) => setForm2({ TRADE_TYPE: e.target.value })}
+          name="tradeType"
+          value={String(formState.tradeType)}
+          onChange={onTradeTypeChange}
+          // onChange={(e) => setForm2({ TRADE_TYPE: e.target.value })}
           categories={tradeCategories}
           showSubCategory={false}
         />

--- a/WebFrontend/src/components/map/LocationSearch.tsx
+++ b/WebFrontend/src/components/map/LocationSearch.tsx
@@ -80,7 +80,7 @@ const LocationSearch = () => {
         <button
           type="button"
           onClick={handleSearch}
-          className="inline-block bg-brand-primary text-white text-caption rounded-md hover:opacity-70 transition px-4 py-3"
+          className="inline-block bg-brand-primary text-white text-caption rounded-[var(--radius-card))] hover:opacity-70 transition px-5 py-3"
         >
           검색
         </button>

--- a/WebFrontend/src/components/map/LocationSelector.tsx
+++ b/WebFrontend/src/components/map/LocationSelector.tsx
@@ -55,7 +55,7 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({ locationId }) => {
             resetLocation();
             setShowSearch(true);
           }}
-          className="inline-block bg-brand-primary text-white text-caption-bold rounded-md hover:opacity-70 transition py-3 px-4"
+          className="inline-block bg-brand-primary text-white text-caption-bold rounded-[var(--radius-card)] hover:opacity-70 transition py-3 px-4"
         >
           다른 장소 선택
         </button>

--- a/WebFrontend/src/index.css
+++ b/WebFrontend/src/index.css
@@ -21,7 +21,7 @@
   --color-brand-text-primary: #000000;    /* 기본 텍스트 색상 */
   --color-brand-inverse: #FFFFFF;    /* 반전 텍스트 색상 */
   --color-brand-text-secondary: #333333;  /* 보조 텍스트 색상 */
-  --color-brand-disabled: AAAAAA#;   /* 비활성화/ 설명 텍스트 색상 */
+  --color-brand-disabled: #AAAAAA;   /* 비활성화/ 설명 텍스트 색상 */
   --color-brand-error-text: #EF4444;      /* 에러 텍스트 색상 */
 
   /* Spacing & Sizing (간격 및 크기) */

--- a/WebFrontend/src/pages/ensemble/components/SessionForm.tsx
+++ b/WebFrontend/src/pages/ensemble/components/SessionForm.tsx
@@ -33,7 +33,7 @@ export const SessionForm: React.FC<SessionFormProps> = ({
   const inputStyles = "w-full py-3 px-4 bg-brand-inverse border border-gray-300 rounded-md box-border text-caption placeholder:text-gray-400 focus:border-[var(--color-brand-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-brand-primary)]";
 
   return (
-    <div className="w-full p-4 mb-4 border border-gray-300 rounded-xl shadow-sm bg-white space-y-4">
+    <div className="w-full p-4 mb-4 border border-gray-300 rounded-xl bg-white space-y-4">
       <div className="">
         <div className="flex flex-col space-y-1">
           <div className="flex flex-row justify-between items-end">

--- a/WebFrontend/src/pages/usedProduct/CreateUsedProductPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/CreateUsedProductPage.tsx
@@ -16,7 +16,7 @@ const CreateUsedProductPage: React.FC = () => {
     title: '',
     description: '',
     price: '',
-    categoryId: '1',
+    categoryId: 0,
     tradeType: TRADE_TYPE.IN_PERSON,
     locationId: '',
   });
@@ -39,6 +39,21 @@ const CreateUsedProductPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [imageIds, setImageIds] = useState<{ id: number; url: string }[]>([]);
+
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setForm((prev) => ({
+      ...prev,
+      categoryId: Number(e.target.value),
+    }));
+  }
+
+
+  const handleTradeTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setForm((prev) => ({
+      ...prev,
+      tradeType: e.target.value as TRADE_TYPE,
+    }));
+  };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -68,12 +83,12 @@ const CreateUsedProductPage: React.FC = () => {
         title: form.title,
         description: form.description,
         price: priceAsNumber,
-        categoryId: parseInt(form.categoryId, 10),
+        categoryId: Number(form.categoryId),
         tradeType: form.tradeType,
         locationId: String(locationId),
         imageIds: imageIds.map((img) => img.id),
       };
-
+      console.log(payload);
       const response = await axiosInstance.post('used-products', payload);
       alert('상품이 성공적으로 등록되었습니다!');
       navigate(`/used-products/${response.data.productId}`);
@@ -99,6 +114,8 @@ const CreateUsedProductPage: React.FC = () => {
         <ProductForm
           formState={form}
           onFormChange={handleChange}
+          onCategoryChange={handleCategoryChange}
+          onTradeTypeChange={handleTradeTypeChange}
           onFormSubmit={handleSubmit}
           isLoading={loading}
           errorMessage={error}

--- a/WebFrontend/src/pages/usedProduct/UpdateUsedProductPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UpdateUsedProductPage.tsx
@@ -20,7 +20,7 @@ const UpdateUsedProductPage: React.FC = () => {
     title: '', 
     description: '', 
     price: '', 
-    categoryId: '',
+    categoryId: 0,
     tradeType: TRADE_TYPE.IN_PERSON, 
     locationId: '',
   });
@@ -52,7 +52,7 @@ const UpdateUsedProductPage: React.FC = () => {
           title: product.title,
           description: product.description,
           price: String(product.price),
-          categoryId: String(product.categoryId),
+          categoryId: product.categoryId,
           tradeType: product.tradeType,
           locationId: String(product.location.locationId),
           // imageIds: imageIds.map((img) => img.id),
@@ -102,7 +102,7 @@ const UpdateUsedProductPage: React.FC = () => {
       const payload = {
         ...form,
         price: priceAsNumber,
-        categoryId: parseInt(form.categoryId, 10),
+        categoryId: form.categoryId,
         locationId: locationId,
         imageIds: imageIds.map((img) => img.id),
       };
@@ -127,6 +127,8 @@ const UpdateUsedProductPage: React.FC = () => {
         <ProductForm
           formState={form}
           onFormChange={handleChange}
+          onCategoryChange={handleChange}
+          onTradeTypeChange={handleChange}
           onFormSubmit={handleSubmit}
           isLoading={loading}
           errorMessage={error}

--- a/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { type UsedProduct, TRADE_TYPE } from '../../types/product';
+import { type UsedProduct, TRADE_TYPE, STATUS, STATUS_TEXT } from '../../types/product';
 import { useAuthStore } from '@/stores/authStore';
 import axiosInstance from '@/services/axiosInstance';
 import useViewCounter from '@/hooks/useViewCounter';
@@ -15,6 +15,8 @@ import MessageInputForm from '@/components/atoms/input/MessageInput';
 import IconButton from '@/components/atoms/button/IconButton';
 import SwiperImageCard from '@/components/atoms/card/SwipeImageCard';
 import { ToastMenu } from '@/components/atoms/button/ToastMenu';
+import { StatusToastMenu } from '@/components/atoms/button/StatusToastMenu';
+import toast from 'react-hot-toast';
 
 const TRADE_TYPE_TEXT = {
   [TRADE_TYPE.IN_PERSON]: '직거래',
@@ -92,6 +94,18 @@ const UsedProductDetailPage: React.FC = () => {
     }
   };
 
+  const handleStatusChange = async (status: STATUS) => {
+    if(!isOwner || !product) return;
+    console.log("상태변경요청");
+    try {
+      const res = await axiosInstance.patch(`/used-products/${product.productId}/status`, {status});
+      setProduct(res.data);
+      toast.success(`게시글 상태가 ${STATUS_TEXT}로 변경되었습니다.`);
+    } catch (err) {
+      toast.error('상태 변경에 실패했습니다.');
+    }
+  };
+
   /**
    * [신규] DM 보내기 버튼 클릭 시 실행되는 함수
    */
@@ -160,12 +174,20 @@ const UsedProductDetailPage: React.FC = () => {
               </div>
             )}
           </div>
-
           <UserProfileCard
-            imageUrl={product.imageUrl ?? ""}
-            name={product.id}
-            location={product.location.address}
-            status="판매중"
+          imageUrl={product.imageUrl ?? ""}
+          name={product.id}
+          location={product.location.address}
+          status={STATUS_TEXT[product.status] as "판매중" | "예약중" | "판매완료"}
+          onClick={() => {
+            console.log('UserProfileCard clicked', { isOwner, product });
+            if(isOwner) {
+            StatusToastMenu({
+              onChangeStatus: handleStatusChange,
+              currentStatus: product.status,
+            })
+            }
+          }}
           />
           {/* 정보 섹션 */}
           <div className="mt-6 md:mt-0 md:flex-1 flex flex-col mb-32">

--- a/WebFrontend/src/pages/usedProduct/UsedProductPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { type UsedProduct, type PaginatedUsedProductResponse } from '../../types/product';
+import { type UsedProduct, type PaginatedUsedProductResponse, CATEGORY_LABEL_TO_ID } from '../../types/product';
 import axiosInstance from '@/services/axiosInstance';
-
 import CategoryList from '@/components/layout/CategoryList';
 import ImageCard from '@/components/atoms/card/ImageCard';
 import FloatingWriteButton from '@/components/atoms/button/FloatingWriteButton';
@@ -19,7 +18,7 @@ const UsedProductPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<Cursor | null>(null);
   const [hasNextPage, setHasNextPage] = useState(true);
-  const [selected, setSelected] = useState("전체");
+  const [selected, setSelected] = useState<string>("전체");
 
   const fetchItems = useCallback(async (isInitialFetch: boolean) => {
     if (loading || !hasNextPage) return;
@@ -29,6 +28,14 @@ const UsedProductPage: React.FC = () => {
 
     try {
       const params = new URLSearchParams({ limit: '12' });
+
+      if(selected !== "전체") {
+        const categoryId = CATEGORY_LABEL_TO_ID[selected];
+        if(categoryId) {
+          params.append("categoryId", String(categoryId));
+        }
+      }
+
       if (!isInitialFetch && nextCursor) {
         params.append('lastProductId', String(nextCursor.lastProductId));
         params.append('lastCreatedAt', nextCursor.lastCreatedAt);
@@ -41,7 +48,11 @@ const UsedProductPage: React.FC = () => {
 
       const { data, nextCursor: newCursor, hasNextPage: newHasNextPage } = response.data;
 
-      setItems(prev => (isInitialFetch ? data : [...prev, ...data]));
+      setItems(prev => (
+        isInitialFetch 
+        ? data 
+        : [...prev, ...data.filter(item => !prev.some(p => p.productId === item.productId))]
+      ));
       setNextCursor(newCursor ?? null);
       setHasNextPage(newHasNextPage);
 
@@ -51,14 +62,21 @@ const UsedProductPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [loading, hasNextPage, nextCursor]);
+  }, [loading, hasNextPage, nextCursor, selected]);
 
   useEffect(() => {
     fetchItems(true);
-  }, []);
+  }, [selected]);
 
   const handleLoadMore = () => {
     fetchItems(false);
+  };
+
+  const handleCategoryClick = (category: string) => {
+    setSelected(category);
+    setNextCursor(null);
+    setHasNextPage(true);
+    fetchItems(true);
   };
 
   return (
@@ -70,7 +88,7 @@ const UsedProductPage: React.FC = () => {
             {/* 카테고리 */}
             <CategoryList
               selectedCategory={selected}
-              onClickCategory={(c) => setSelected(c)}
+              onClickCategory={handleCategoryClick}
             />
               {/* 게시물 그리드 */}
             <div className="grid grid-cols-1 gap-[16px] max-w-[410px] mx-auto mt-[40px] mb-[52px]">

--- a/WebFrontend/src/types/product.ts
+++ b/WebFrontend/src/types/product.ts
@@ -1,13 +1,43 @@
+// 👇 백엔드 ENUM 과 일치화
 export enum STATUS {
   FOR_SALE = 'FOR_SALE',
   IN_PROGRESS = 'IN_PROGRESS',
   SOLD = 'SOLD',
 }
 
+// 프론트 TEXT 필터 렌더링을 위한 이름
+export const STATUS_TEXT = {
+  FOR_SALE: '판매중',
+  IN_PROGRESS: '예약중',
+  SOLD: '판매완료',
+} as const;
+
+// 👇 백엔드 ENUM 과 일치화
 export enum TRADE_TYPE {
-  IN_PERSON,
-  DELIVERY,
+  IN_PERSON = 'IN_PERSON',
+  DELIVERY = 'DELIVERY',
 }
+
+// 프론트 ENUM - 백엔드 Number 타입
+export enum ProductCategory {
+  BASS = 1,
+  ELECTRIC = 2,
+  CLASSIC = 3,
+  ACOUSTIC = 4,
+}
+
+// 프론트 TEXT 필터 렌더링을 위한 이름
+export const PRODUCT_CATEGORY_LABELS: Record<ProductCategory, string> = {
+  [ProductCategory.BASS]: '베이스기타',
+  [ProductCategory.ELECTRIC]: '일렉기타',
+  [ProductCategory.CLASSIC]: '클래식기타',
+  [ProductCategory.ACOUSTIC]: '통기타',
+};
+
+// 카테고리 id to label 역매핑 (필요시)
+export const CATEGORY_LABEL_TO_ID: Record<string, ProductCategory> = Object.fromEntries(
+  Object.entries(PRODUCT_CATEGORY_LABELS).map(([id, name]) => [name, Number(id)])
+);
 
 export interface Location {
   locationId: string;
@@ -44,7 +74,7 @@ export interface UsedProductForm {
   title: string;
   description: string;
   price: string; // 폼 입력값은 보통 문자열
-  categoryId: string; // 폼 선택값도 보통 문자열
+  categoryId: number; // 폼 선택값도 보통 문자열
   tradeType: TRADE_TYPE;
   locationId: string; // 폼에서는 지역의 ID만 관리
   location?: Location;


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [x] 백엔드 ENUM 타입 (`tradeType`, `Status`)을 프론트에서 타입으로 연동하여 사용하도록 수정
- [x] 작성자인 경우 STATUS를 바꾸는 FE UI, BE 로직을 추가 
- [x] `categoryId`에 해당하는 타입 정의 및 매핑 로직을 FE에 추가
- [x] 프론트에서 카테고리 필터 선택 시, `categoryId` 기준으로 백엔드에 필터링 요청하도록 구현
- [x] 선택된 카테고리에 맞는 게시글만 렌더링되도록 필터링 로직 적용


## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 카테고리 필터 작동 여부 확인
2. 판매중, 예약중, 판매완료 버튼 작동 여부 확인
3. tradeType, Status가 DB에 올바르게 매핑 되는지 확인


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.