### PR TITLE
feat: Implement conditional scroll to new comments

### DIFF
--- a/WebFrontend/src/components/atoms/input/MessageInput.tsx
+++ b/WebFrontend/src/components/atoms/input/MessageInput.tsx
@@ -1,6 +1,6 @@
 // src/components/atoms/input/MessageInput.tsx
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import Icon from '@/components/atoms/icon/Icon';
 import TextareaAutosize from 'react-textarea-autosize';
 
@@ -11,13 +11,7 @@ interface MessageInputFormProps {
 
 const MessageInputForm: React.FC<MessageInputFormProps> = ({ onSubmit, onDmClick }) => {
   const [message, setMessage] = useState('');
-  // const PLACEHOLDER_TEXT = "안녕하세요. 구매 가능할까요?";
-  
-  // const handleFocus = () => {
-  //   if (!message) {
-  //     setMessage(PLACEHOLDER_TEXT);
-  //   }
-  // };
+  const formRef = useRef<HTMLFormElement>(null); 
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,8 +20,20 @@ const MessageInputForm: React.FC<MessageInputFormProps> = ({ onSubmit, onDmClick
     setMessage('');
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // 한글 등 조합형 문자 입력 시에는 Enter를 눌러도 바로 전송되지 않도록 합니다.
+    if (e.nativeEvent.isComposing) return;
+
+    // Shift 키 없이 Enter만 눌렀을 때
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault(); // 기본 동작(줄바꿈)을 막습니다.
+      formRef.current?.requestSubmit(); // form의 submit을 프로그래밍적으로 호출합니다.
+    }
+  };
+
   return (
     <form
+      ref={formRef}
       onSubmit={handleSubmit}
       className="fixed bottom-20 left-1/2 translate-x-[-50%] w-full max-w-[410px] flex gap-2 z-20 px-2 mb-0 mt-16"
     >
@@ -44,6 +50,7 @@ const MessageInputForm: React.FC<MessageInputFormProps> = ({ onSubmit, onDmClick
         placeholder="메세지를 입력하세요."
         value={message}
         onChange={(e) => setMessage(e.target.value)}
+        onKeyDown={handleKeyDown}
         className="flex-1 border border-gray-400 rounded-card px-3 py-2 text-caption bg-brand-inverse focus:outline-none focus:ring-1 focus:ring-brand-primary resize-none"
         minRows={1}
         maxRows={4}

--- a/WebFrontend/src/pages/chat/ChatRoomPage.tsx
+++ b/WebFrontend/src/pages/chat/ChatRoomPage.tsx
@@ -1,3 +1,5 @@
+// WebFrontend/src/pages/chat/ChatRoomPage.tsx
+
 import React, { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { motion, useMotionValue } from "framer-motion";

--- a/WebFrontend/src/pages/community/PostDetailPage.tsx
+++ b/WebFrontend/src/pages/community/PostDetailPage.tsx
@@ -1,6 +1,6 @@
 // src/pages/community/PostDetailPage.tsx
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useParams} from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import axiosInstance from '../../services/axiosInstance'; // 인증이 필요한 요청을 위한 Axios 인스턴스
@@ -82,6 +82,8 @@ const PostDetailPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const commentsEndRef = useRef<HTMLDivElement>(null);
+
   // 데이터 로딩 로직 
   useEffect(() => {
     if (!id) {
@@ -107,7 +109,6 @@ const PostDetailPage: React.FC = () => {
     };
     loadData();
   }, [id]);
-
   
   // 댓글 등록 로직
   const handleCommentSubmit = async (commentText: string) => {
@@ -122,7 +123,10 @@ const PostDetailPage: React.FC = () => {
             content: commentText,
         });
         setComments(prevComments => [...prevComments, createdComment]);
-        // 입력창 비우기는 MessageInputForm이 스스로 처리하므로 여기선 필요 없습니다.
+        
+        setTimeout(() => {
+          commentsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }, 100);
     } catch (error) {
         alert('댓글 등록에 실패했습니다.');
         console.error(error);
@@ -181,6 +185,7 @@ const PostDetailPage: React.FC = () => {
                     formatDate={formatDate}
                   />
               ))}
+              <div ref={commentsEndRef} />
           </div>
         </section>
       </div> {/* <--- 1. 스크롤 영역 div가 여기서 끝납니다. */}


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [ ] useEffect를 사용해 댓글 목록(comments)이 변경될 때마다 스크롤이 트리거되어, 페이지 첫 로드 시에도 불필요한 스크롤이 발생하던 문제해결
- [ ] handleCommentSubmit 함수 내에서 댓글 등록이 성공한 직후에만 scrollIntoView를 호출하도록 로직 변경
- [ ] setTimeout을 적용하여 React의 렌더링이 완료된 후 스크롤이 실행


## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 게시글 상세 페이지에 처음 접속
2. 페이지가 최상단 게시글 내용에 포커스되어 있고, 하단 댓글 목록으로 자동 스크롤되지 않는 것을 확인
3. 로그인 후, 댓글을 작성하고 등록 버튼 누르기
4. 댓글이 등록됨과 동시에, 화면이 부드럽게 스크롤되어 방금 작성한 새 댓글이 보이는지 확인


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.