### PR TITLE
fix: Adjust UI on login and registration pages

### DIFF
--- a/WebFrontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/WebFrontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -94,7 +94,7 @@ const ForgotPasswordPage: React.FC = () => {
   return (
     <div className="centered-card-container px-4">
       <div className="w-full max-w-md">
-        {/* ... 로고, 헤더 부분은 동일 ... */}
+        {/* ... 로고, 헤더 부분 ... */}
         <div className="sm:mx-auto sm:w-full">
           <Link to="/login">
             <img className="mx-auto h-12 w-auto" src="/RechoLogo.png" alt="Recho Logo" />

--- a/WebFrontend/src/pages/auth/LoginPage.tsx
+++ b/WebFrontend/src/pages/auth/LoginPage.tsx
@@ -14,7 +14,6 @@ const LoginPage: React.FC = () => {
 
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
-  const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -38,10 +37,7 @@ const LoginPage: React.FC = () => {
     }
   };
 
-  // handleRegisterClick 함수는 이제 Link 컴포넌트로 대체되므로 삭제합니다.
-
   return (
-    // 커스텀 클래스 .centered-card-container 적용
     <div className="centered-card-container px-4">
       <div className="w-full max-w-md">
         <div className="sm:mx-auto sm:w-full">
@@ -50,124 +46,66 @@ const LoginPage: React.FC = () => {
             src="/RechoLogo.png"
             alt="Recho"
           />
-          {/* 커스텀 클래스 .text-title 적용 */}
           <h2 className="mt-6 text-center text-body text-[var(--color-brand-text-primary)]">
             음악으로 나를 알리는 플랫폼
           </h2>
         </div>
 
-        {/* 커스텀 변수 --color-brand-default, --radius-card 적용 */}
         <div>
           <form className="space-y-4 mt-4" onSubmit={handleSubmit}>
             <div>
-              {/* 1. 아이콘과 input을 감싸는 div에 relative 추가 */}
               <div className="relative mt-1">
-                {/* 2. 아이콘을 담는 div (절대 위치로 배치) */}
-                <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                  {/* User 아이콘 SVG */}
-                  <svg
-                    className="h-5 w-5 text-gray-400"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                {/* 3. input에 왼쪽 패딩(pl-10) 추가 */}
-                <div>
-                  <TextInput
-                    id="id"
-                    type="text"
-                    required
-                    value={id}
-                    onChange={(e) => setId(e.target.value)}
-                    placeholder="아이디를 입력해주세요."
-                    icon={
-                      <svg
-                        className="h-5 w-5 text-gray-400"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                    }
-                  />
-                </div>
+                <TextInput
+                  id="id"
+                  type="text"
+                  required
+                  value={id}
+                  onChange={(e) => setId(e.target.value)}
+                  placeholder="아이디를 입력해주세요."
+                  icon={
+                    <svg
+                      className="h-5 w-5 text-gray-400"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  }
+                />
               </div>
             </div>
 
             <div>
-              {/* 1. 아이콘과 input을 감싸는 div에 relative 추가 */}
               <div className="relative mt-1">
-                {/* 2. 아이콘을 담는 div (절대 위치로 배치) */}
-                <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                  {/* Lock 아이콘 SVG */}
-                  <svg
-                    className="h-5 w-5 text-gray-400"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                {/* 3. input에 왼쪽 패딩(pl-10) 추가 */}
-                <div>
-                  <TextInput
-                    id="password"
-                    type="password"
-                    required
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder="비밀번호를 입력해주세요."
-                    icon={
-                      <svg
-                        className="h-5 w-5 text-gray-400"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                    }
-                  />
-                </div>
+                <TextInput
+                  id="password"
+                  type="password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="비밀번호를 입력해주세요."
+                  icon={
+                    <svg
+                      className="h-5 w-5 text-gray-400"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  }
+                />
               </div>
             </div>
 
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <input
-                  id="remember-me"
-                  type="checkbox"
-                  checked={rememberMe}
-                  onChange={(e) => setRememberMe(e.target.checked)}
-                  className="h-4 w-4 rounded border-brand-disabled text-[var(--color-brand-primary)] focus:ring-[var(--color-brand-primary)]"
-                />
-                <label
-                  htmlFor="remember-me"
-                  className="ml-2 block text-caption text-[var(--color-brand-gray)]"
-                >
-                  Remember me
-                </label>
-              </div>
-
+            <div className="flex justify-end">
               <div className="text-sm">
                 <Link
                   to="/forgot-password"
@@ -187,7 +125,7 @@ const LoginPage: React.FC = () => {
             </div>
           </form>
 
-          {/* 소셜 로그인 UI (커스텀 스타일 적용) */}
+          {/* 소셜 로그인 UI */}
           <div className="mt-6">
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
@@ -195,7 +133,6 @@ const LoginPage: React.FC = () => {
               </div>
               <div className="relative flex justify-center text-sm">
                 <span className="bg-[var(--color-brand-frame)] px-2 text-caption text-[var(--color-brand-gray)]">
-                  소셜 계정으로 로그인하기
                 </span>
               </div>
             </div>
@@ -205,13 +142,19 @@ const LoginPage: React.FC = () => {
                 href={import.meta.env.VITE_GOOGLE_LOGIN_URL}
                 className="inline-flex w-full justify-center rounded-[var(--radius-button)] border border-gray-300 bg-white py-2 px-4 text-navigation font-medium text-gray-500 hover:bg-gray-50"
               >
+                {/* --- Google 로고 SVG (수정됨) --- */}
                 <svg
                   className="mr-3 h-5 w-5"
                   aria-hidden="true"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
+                  focusable="false"
+                  role="img"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
                 >
-                  <path d="M6.29 18.25a.75.75 0 00.75.75h6a.75.75 0 00.75-.75v-3.25H6.29v3.25zM12.5 4.5h-5A3.5 3.5 0 004 8v5a3.5 3.5 0 003.5 3.5h5A3.5 3.5 0 0016 13V8a3.5 3.5 0 00-3.5-3.5z"></path>
+                  <path
+                    d="M21.35,11.1H12.18V13.83H18.69C18.36,17.64 15.19,19.27 12.19,19.27C8.36,19.27 5,16.25 5,12C5,7.9 8.2,4.73 12.19,4.73C15.29,4.73 17.1,6.7 17.1,6.7L19,4.72C19,4.72 16.56,2 12.1,2C6.42,2 2.03,6.8 2.03,12C2.03,17.05 6.16,22 12.25,22C17.6,22 21.5,18.33 21.5,12.91C21.5,11.76 21.35,11.1 21.35,11.1Z"
+                    fill="currentColor"
+                  ></path>
                 </svg>
                 Google
               </a>
@@ -221,18 +164,23 @@ const LoginPage: React.FC = () => {
               >
                 <svg
                   className="mr-3 h-5 w-5"
-                  fill="currentColor"
+                  aria-hidden="true"
+                  focusable="false"
+                  role="img"
+                  xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 24 24"
                 >
-                  {/* 카카오 로고 SVG Path */}
-                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1.11 14.23l-.01.01-2.43-1.2-1.2 2.43c-.02.04-.06.07-.1.08-.04.02-.09.01-1.3-.7l-1.12-1.12c-.05-.05-.06-.12-.01-.17l2.43-4.21-4.21 2.43c-.05.04-.12.04-.17-.01l-1.12-1.12c-.71-1.2-.68-1.26-.7-1.3-.01-.04.01-.09.08-.1l2.43-1.2-1.2-2.43c-.04-.05-.04-.12.01-.17l1.12-1.12c1.2-.71 1.26-.68 1.3-.7.04-.01.09-.01.1.08l1.2 2.43 2.43-1.2c.05-.04.12-.04.17.01l1.12 1.12c.71 1.2.68 1.26.7 1.3.01-.04-.01.09-.08-.1l-2.43 1.2 1.2 2.43c.04.05.04.12-.01-.17l-1.12 1.12c-.52.31-1.27.76-1.27.76z" />
+                  <path
+                    fill="currentColor"
+                    d="M12.1,2C6.5,2,2,5.7,2,10.2c0,3.1,2,5.8,5,7.1c-0.2,0.7-0.7,2-0.8,2.3c-0.1,0.3,0,0.5,0.2,0.7c0.2,0.1,0.5,0.1,0.7,0c0.3-0.1,2.5-1.5,3.7-2.3c0.4,0,0.8,0.1,1.2,0.1c5.6,0,10.1-3.7,10.1-8.2S17.7,2,12.1,2z"
+                  ></path>
                 </svg>
                 Kakao
               </a>
             </div>
           </div>
         </div>
-        <p className="mt-10 text-center text-caption text-[var(--color-brand-gray)]">
+        <p className="mt-9 text-center text-caption text-[var(--color-brand-gray)]">
           회원이 아니신가요?{" "}
           <Link
             to="/register"

--- a/WebFrontend/src/pages/auth/RegisterPage.tsx
+++ b/WebFrontend/src/pages/auth/RegisterPage.tsx
@@ -1,8 +1,9 @@
 // src/pages/RegisterPage.tsx
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import PrimaryButton from "@/components/atoms/button/PrimaryButton";
+import SecondaryButton from "@/components/atoms/button/SecondaryButton";
 import TextInput from "@/components/atoms/input/TextInput";
 import axiosInstance from "@/services/axiosInstance";
 import { AxiosError } from "axios";
@@ -18,182 +19,132 @@ const RegisterPage: React.FC = () => {
   const [confirmPassword, setConfirmPassword] = useState("");
 
   // 에러 및 로딩 상태
-  const [idError, setIdError] = useState("");
-  const [usernameError, setUsernameError] = useState("");
-  const [emailError, setEmailError] = useState("");
-  const [passwordError, setPasswordError] = useState("");
-  const [passwordConfirmError, setPasswordConfirmError] = useState("");
-  const [formError, setFormError] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [loadingState, setLoadingState] = useState<"id" | "username" | "email" | "submit" | null>(null);
 
-  // 중복 및 유효성 확인 통과 여부 상태
-  const [isIdChecked, setIsIdChecked] = useState(false);
-  const [isUsernameChecked, setIsUsernameChecked] = useState(false);
-  const [isEmailChecked, setIsEmailChecked] = useState(false);
-  const [isPasswordValid, setIsPasswordValid] = useState(false);
-
-  // 입력값이 변경되면 확인 상태를 초기화
-  useEffect(() => {
-    setIsIdChecked(false);
-  }, [id]);
-
-  useEffect(() => {
-    setIsUsernameChecked(false);
-  }, [username]);
+  // 단계별 인증 완료 상태 (ForgotPasswordPage와 동일한 로직)
+  const [isIdVerified, setIsIdVerified] = useState(false);
+  const [isUsernameVerified, setIsUsernameVerified] = useState(false);
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
   
-  useEffect(() => {
-    setIsEmailChecked(false);
-  }, [email]);
-
-  // 비밀번호 유효성 실시간 검사
-  useEffect(() => {
-    const hasMinLength = password.length >= 8;
-    const hasLetter = /[a-zA-Z]/.test(password);
-    const hasNumber = /[0-9]/.test(password);
-    const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
-
-    if (password && (!hasMinLength || !hasLetter || !hasNumber || !hasSpecialChar)) {
-      setPasswordError("비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 모두 포함해야 합니다.");
-      setIsPasswordValid(false);
-    } else {
-      setPasswordError("");
-      setIsPasswordValid(password ? true : false);
-    }
-
-    if (confirmPassword && password !== confirmPassword) {
-      setPasswordConfirmError("비밀번호가 일치하지 않습니다.");
-    } else {
-      setPasswordConfirmError("");
-    }
-  }, [password, confirmPassword]);
-
-  // 아이디 중복 확인 핸들러
+  // 1. 아이디 중복 확인 핸들러
   const handleCheckId = async () => {
+    setError("");
     if (!id) {
-      setIdError("아이디를 입력해주세요.");
+      setError("아이디를 입력해주세요.");
       return;
     }
     const hasLetter = /[a-zA-Z]/;
     const hasNumber = /[0-9]/;
     if (!hasLetter.test(id) || !hasNumber.test(id)) {
-      setIdError("아이디는 영문과 숫자를 모두 포함해야 합니다.");
-      setIsIdChecked(false);
+      setError("아이디는 영문과 숫자를 모두 포함해야 합니다.");
       return;
     }
+    setLoadingState("id");
     try {
       await axiosInstance.post("/users/check-id", { id });
-      setIdError("");
       alert("사용 가능한 아이디입니다.");
-      setIsIdChecked(true);
+      setIsIdVerified(true);
     } catch (err) {
-      const error = err as AxiosError<{ message: string }>;
-      setIdError(error.response?.data?.message || "아이디 중복 확인 실패");
-      setIsIdChecked(false);
+      const axiosError = err as AxiosError<{ message: string }>;
+      setError(axiosError.response?.data?.message || "사용할 수 없는 아이디입니다.");
+    } finally {
+      setLoadingState(null);
     }
   };
 
-  // [수정됨] 닉네임 중복 확인 핸들러 (유효성 검사 없음)
+  // 2. 닉네임 중복 확인 핸들러
   const handleCheckUsername = async () => {
+    setError("");
     if (!username) {
-      setUsernameError("닉네임을 입력해주세요.");
+      setError("닉네임을 입력해주세요.");
       return;
     }
-
+    setLoadingState("username");
     try {
       await axiosInstance.post("/users/check-username", { username });
-      setUsernameError(""); // 에러 메시지 초기화
       alert("사용 가능한 닉네임입니다.");
-      setIsUsernameChecked(true);
+      setIsUsernameVerified(true);
     } catch (err) {
-      const error = err as AxiosError<{ message: string }>;
-      setUsernameError(error.response?.data?.message || "닉네임 중복 확인 실패");
-      setIsUsernameChecked(false);
+      const axiosError = err as AxiosError<{ message: string }>;
+      setError(axiosError.response?.data?.message || "사용할 수 없는 닉네임입니다.");
+    } finally {
+      setLoadingState(null);
     }
   };
-  
-  // 이메일 중복 확인 핸들러
+
+  // 3. 이메일 중복 확인 핸들러
   const handleCheckEmail = async () => {
+    setError("");
     if (!email) {
-      setEmailError("이메일을 입력해주세요.");
+      setError("이메일을 입력해주세요.");
       return;
     }
     if (!/\S+@\S+\.\S+/.test(email)) {
-      setEmailError("올바른 이메일 형식이 아닙니다.");
+      setError("올바른 이메일 형식이 아닙니다.");
       return;
     }
+    setLoadingState("email");
     try {
       await axiosInstance.post("/users/check-email", { email });
-      setEmailError("");
       alert("사용 가능한 이메일입니다.");
-      setIsEmailChecked(true);
+      setIsEmailVerified(true);
     } catch (err) {
-      const error = err as AxiosError<{ message: string }>;
-      setEmailError(error.response?.data?.message || "이메일 중복 확인 실패");
-      setIsEmailChecked(false);
+      const axiosError = err as AxiosError<{ message: string }>;
+      setError(axiosError.response?.data?.message || "사용할 수 없는 이메일입니다.");
+    } finally {
+      setLoadingState(null);
     }
   };
 
-  // 가입하기 버튼 클릭 핸들러
+  // 4. 최종 가입하기 핸들러
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setFormError("");
+    setError("");
 
-    if (!isIdChecked) {
-      setFormError("아이디 중복 확인을 해주세요.");
+    if (!isIdVerified || !isUsernameVerified || !isEmailVerified) {
+      setError("모든 항목의 중복 확인을 완료해주세요.");
       return;
     }
-    if (!isUsernameChecked) {
-      setFormError("닉네임 중복 확인을 해주세요.");
+    const hasMinLength = password.length >= 8;
+    const hasLetter = /[a-zA-Z]/.test(password);
+    const hasNumber = /[0-9]/.test(password);
+    const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+
+    if (!password || !confirmPassword) {
+      setError("비밀번호를 입력해주세요.");
       return;
     }
-    if (!isEmailChecked) {
-      setFormError("이메일 중복 확인을 해주세요.");
-      return;
-    }
-    if (!isPasswordValid) {
-      setFormError("비밀번호가 보안 규칙에 맞지 않습니다.");
+    if (!hasMinLength || !hasLetter || !hasNumber || !hasSpecialChar) {
+      setError("비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 모두 포함해야 합니다.");
       return;
     }
     if (password !== confirmPassword) {
-      setFormError("비밀번호가 일치하지 않습니다.");
+      setError("비밀번호가 일치하지 않습니다.");
       return;
     }
 
-    setIsLoading(true);
-
+    setLoadingState("submit");
     try {
-      await axiosInstance.post("users", {
-        id,
-        username,
-        email,
-        password,
-      });
-
+      await axiosInstance.post("users", { id, username, email, password });
       alert("회원가입에 성공했습니다! 로그인 페이지로 이동합니다.");
       navigate("/login");
     } catch (err) {
-      const error = err as AxiosError<{ message: string }>;
-      console.error("Registration error:", err);
-      const errorMessage = Array.isArray(error.response?.data?.message)
-        ? error.response?.data?.message[0]
-        : error.response?.data?.message || "알 수 없는 에러가 발생했습니다.";
-      setFormError(errorMessage);
+      const axiosError = err as AxiosError<{ message: string | string[] }>;
+      const errorMessage = Array.isArray(axiosError.response?.data?.message)
+        ? axiosError.response?.data?.message[0]
+        : axiosError.response?.data?.message || "회원가입 중 오류가 발생했습니다.";
+      setError(errorMessage);
     } finally {
-      setIsLoading(false);
+      setLoadingState(null);
     }
   };
-
-  const allChecksPassed = isIdChecked && isUsernameChecked && isEmailChecked && isPasswordValid && password === confirmPassword;
 
   return (
     <div className="centered-card-container px-4">
       <div className="w-full max-w-md">
         <div className="sm:mx-auto sm:w-full">
-          <img
-            className="mx-auto h-12 w-auto"
-            src="/RechoLogo.png"
-            alt="Recho Logo"
-          />
+          <img className="mx-auto h-12 w-auto" src="/RechoLogo.png" alt="Recho Logo" />
           <h2 className="mt-6 text-center text-subheadline text-[var(--color-brand-text-primary)]">
             회원가입
           </h2>
@@ -202,105 +153,97 @@ const RegisterPage: React.FC = () => {
         <div>
           <form className="space-y-4 mt-4" onSubmit={handleSubmit}>
             {/* 아이디 */}
-            <div className="flex items-start space-x-2">
-              <div className="flex-grow">
-                <TextInput
-                  id="id"
-                  type="text"
-                  required
-                  value={id}
-                  onChange={(e) => setId(e.target.value)}
-                  placeholder="아이디 (영문, 숫자 조합)"
-                />
-                {idError && <p className="mt-1 text-sm text-error">{idError}</p>}
-              </div>
-              <button
+            <div className="flex items-center space-x-2">
+              <TextInput
+                id="id"
+                type="text"
+                required
+                value={id}
+                onChange={(e) => setId(e.target.value)}
+                placeholder="아이디 (영문, 숫자 조합)"
+                disabled={isIdVerified}
+              />
+              <SecondaryButton
                 type="button"
                 onClick={handleCheckId}
-                className="btn-check-duplicate"
+                disabled={isIdVerified || loadingState !== null}
+                style={{ height: '34.8px', flexShrink: 0 }}
               >
-                중복 확인
-              </button>
+                {loadingState === "id" ? "확인 중..." : "중복 확인"}
+              </SecondaryButton>
             </div>
 
             {/* 닉네임 */}
-            <div className="flex items-start space-x-2">
-              <div className="flex-grow">
-                <TextInput
-                  id="username"
-                  type="text"
-                  required
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder="닉네임을 입력해주세요"
-                />
-                {usernameError && <p className="mt-1 text-sm text-error">{usernameError}</p>}
-              </div>
-              <button
+            <div className="flex items-center space-x-2">
+              <TextInput
+                id="username"
+                type="text"
+                required
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="닉네임"
+                disabled={!isIdVerified || isUsernameVerified}
+              />
+              <SecondaryButton
                 type="button"
                 onClick={handleCheckUsername}
-                className="btn-check-duplicate"
+                disabled={!isIdVerified || isUsernameVerified || loadingState !== null}
+                style={{ height: '34.8px', flexShrink: 0 }}
               >
-                중복 확인
-              </button>
-            </div>
-            
-            {/* 이메일 */}
-            <div className="flex items-start space-x-2">
-                <div className="flex-grow">
-                    <TextInput
-                      id="email"
-                      type="email"
-                      required
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      placeholder="이메일을 입력해주세요"
-                    />
-                    {emailError && <p className="mt-1 text-sm text-error">{emailError}</p>}
-                </div>
-                <button
-                    type="button"
-                    onClick={handleCheckEmail}
-                    className="btn-check-duplicate"
-                >
-                    중복 확인
-                </button>
-            </div>
-            
-            {/* 비밀번호 */}
-            <div>
-              <TextInput
-                id="password"
-                type="password"
-                required
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="비밀번호"
-              />
-              {passwordError && <p className="mt-1 text-sm text-error">{passwordError}</p>}
-            </div>
-            
-            {/* 비밀번호 확인 */}
-            <div>
-              <TextInput
-                id="confirmPassword"
-                type="password"
-                required
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                placeholder="비밀번호 확인"
-              />
-              {passwordConfirmError && <p className="mt-1 text-sm text-error">{passwordConfirmError}</p>}
+                {loadingState === "username" ? "확인 중..." : "중복 확인"}
+              </SecondaryButton>
             </div>
 
-            {formError && <p className="text-center text-error">{formError}</p>}
+            {/* 이메일 */}
+            <div className="flex items-center space-x-2">
+              <TextInput
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="이메일"
+                disabled={!isUsernameVerified || isEmailVerified}
+              />
+              <SecondaryButton
+                type="button"
+                onClick={handleCheckEmail}
+                disabled={!isUsernameVerified || isEmailVerified || loadingState !== null}
+                style={{ height: '34.8px', flexShrink: 0 }}
+              >
+                {loadingState === "email" ? "확인 중..." : "중복 확인"}
+              </SecondaryButton>
+            </div>
+            
+            {isEmailVerified && <div className="border-t border-gray-200" />}
+
+            {/* 비밀번호 */}
+            <TextInput
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="비밀번호 (영문, 숫자, 특수문자 조합 8자 이상)"
+              disabled={!isEmailVerified}
+            />
+
+            {/* 비밀번호 확인 */}
+            <TextInput
+              id="confirmPassword"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="비밀번호 확인"
+              disabled={!isEmailVerified}
+            />
+
+            {error && <p className="text-center text-error">{error}</p>}
 
             <div className="pt-2">
-              <PrimaryButton
-                type="submit"
-                disabled={isLoading || !allChecksPassed}
-              >
-                {isLoading ? "가입하는 중..." : "가입하기"}
+              <PrimaryButton type="submit" disabled={!isEmailVerified || loadingState !== null}>
+                {loadingState === "submit" ? "가입하는 중..." : "가입하기"}
               </PrimaryButton>
             </div>
           </form>
@@ -308,32 +251,11 @@ const RegisterPage: React.FC = () => {
 
         <p className="mt-10 text-center text-caption text-[var(--color-brand-gray)]">
           이미 계정이 있으신가요?{" "}
-          <Link
-            to="/login"
-            className="text-navigation font-semibold text-[var(--color-brand-blue)] hover:opacity-80"
-          >
+          <Link to="/login" className="text-navigation font-semibold text-[var(--color-brand-blue)] hover:opacity-80">
             로그인 하기
           </Link>
         </p>
       </div>
-      <style>{`
-        .btn-check-duplicate {
-          padding: 0 1rem;
-          height: 2.5rem;
-          margin-top: 1px;
-          border: 1px solid transparent;
-          font-size: 0.875rem;
-          font-weight: 500;
-          border-radius: 0.375rem;
-          box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-          color: white;
-          background-color: var(--color-brand-blue);
-          white-space: nowrap;
-        }
-        .btn-check-duplicate:hover {
-          opacity: 0.8;
-        }
-      `}</style>
     </div>
   );
 };


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [ ] 로그인 페이지의 소셜 로그인 버튼 아이콘(Google, Kakao)을 올바른 SVG로 교체
- [ ] 'Remember me' 체크박스 제거 후 'Forgot password?' 링크 우측 정렬
- [ ] 회원가입 페이지의 단계별 UI 확인 로직 수정 


## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. Google, Kakao 소셜 로그인 버튼의 로고가 정상적으로 표시되는지 확인
2. Remember me 체크박스가 사라졌는지 확인
3. Forgot password? 링크가 우측에 정상적으로 정렬되어 있는지 확인
4. 회원가입 과정 확인
5. 


## 🖼️ 스크린샷 (선택 사항)
<img width="448" height="779" alt="스크린샷 2025-07-16 오전 2 01 59" src="https://github.com/user-attachments/assets/13674bb4-932a-4ce7-8510-06520d85ca33" />
<img width="458" height="730" alt="스크린샷 2025-07-16 오전 2 02 12" src="https://github.com/user-attachments/assets/875235af-4dd1-4683-8351-3bd7d6593076" />

## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.