### PR TITLE
fix: 다른 페이지로 이동할 경우 toast 팝업이 자동으로 사라지도록 변경

### DIFF
--- a/WebFrontend/src/components/atoms/button/StatusToastMenu.tsx
+++ b/WebFrontend/src/components/atoms/button/StatusToastMenu.tsx
@@ -64,5 +64,6 @@ export const StatusToastMenu = ({
   ), {
     duration: Infinity,     // 토스트 팝업 지속 시간
     position: 'bottom-center',
+    id: 'status-toast',
   });
 };

--- a/WebFrontend/src/pages/ensemble/RecruitEnsemblePage.tsx
+++ b/WebFrontend/src/pages/ensemble/RecruitEnsemblePage.tsx
@@ -96,6 +96,13 @@ const RecruitEnsembleListPage: React.FC = () => {
     })
   }
 
+  // toast unmount 시 close. DOM 에서 토스트가 내려가면 호출됩니다
+  useEffect(() => {
+    return () => {
+      toast.dismiss("filter-toast");
+    };
+  }, []);
+
   return (
     <PostLayout>
       <div className="grid grid-cols-1 py-4">

--- a/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
@@ -137,6 +137,13 @@ const UsedProductDetailPage: React.FC = () => {
     </div>
   );
 
+  // toast unmount 시 close. DOM 에서 토스트가 내려가면 호출됩니다
+  useEffect(() => {
+    return () => {
+      toast.dismiss("status-toast");
+    };
+  }, []);
+
   if (loading) return renderStatusMessage('로딩 중...');
   if (error) return renderStatusMessage(error, true);
   if (!product) return renderStatusMessage('상품 정보가 없습니다.', true);


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [ ] 다른 페이지로 이동할 경우 toast 팝업이 자동으로 사라지도록 useEffect로 toast.dismiss를 상위 페이지에서 호출합니다.
- [ ] 
- [ ] 


## 🔗 관련 이슈
Closes #163 


## ✓ 테스트 방법
1. 
2. 
3. 


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.