### PR TITLE
fix: 엔드 포인트 위치 오류

### DIFF
--- a/VideoEditorApp/src/screens/VideoEditScreen.tsx
+++ b/VideoEditorApp/src/screens/VideoEditScreen.tsx
@@ -747,9 +747,19 @@ const VideoEditScreen: React.FC<{
     }
 
     const trackStartTimes = trimmers.map(t => t.timelinePosition);
-    const trackEndTimes = trimmers.map(
-      t => t.timelinePosition + (t.endTime - t.startTime),
-    );
+    // [수정] trackEndTime 계산 시 timelinePosition이 음수인 경우를 고려
+    const trackEndTimes = trimmers.map(t => {
+      const clipDuration = t.endTime - t.startTime;
+      const trackEndTime = t.timelinePosition + clipDuration;
+      
+      // timelinePosition이 음수인 경우, 실제 비디오의 끝점을 올바르게 계산
+      if (t.timelinePosition < 0) {
+        // 음수 timelinePosition을 보정하여 실제 끝점 계산
+        return Math.max(trackEndTime, t.endTime);
+      }
+      
+      return trackEndTime;
+    });
 
     let maxStart = Math.max(...trackStartTimes);
     let minEnd = Math.min(...trackEndTimes);


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [ ] 엔드 포인트이 포지션 음수 값과 역여서 잘못 계산되는 오류 수정 했습니다.



## 🔗 관련 이슈
Closes #192 



## ✓ 테스트 방법
1. 포지션과 역인 엔드 포인트 확인 해보세요.


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.