### PR TITLE
feat: 채팅 알람 및 실시간 통신 구현 #243

### DIFF
--- a/BackendServer/src/chat/chat.controller.ts
+++ b/BackendServer/src/chat/chat.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   UseGuards,
   Req,
+  HttpCode,
 } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { CreateRoomDto } from './dto/create-room.dto';
@@ -59,22 +60,44 @@ export class ChatController {
 
   // 3) 메시지 이력 조회
   @Get('rooms/:id/history')
-  @UseGuards(AuthGuard('jwt')) // [수정] JWT 가드를 추가하여 인증된 사용자만 접근 가능하도록 변경
+  @UseGuards(AuthGuard('jwt'))
   async getHistory(
     @Param('id') roomId: string,
     @Query() query: HistoryQueryDto,
-    @Req() req: RequestWithUser, // [수정] 요청 객체에서 사용자 정보를 가져옴
+    @Req() req: RequestWithUser,
   ): Promise<Message[]> {
-    const id = req.user.id; // [수정] 현재 로그인한 사용자의 ID
-    // [수정] 서비스 호출 시 id를 함께 전달
-    return this.chatService.getHistory(roomId, id, query.page, query.limit);
+    const userId = req.user.id;
+    return this.chatService.getHistory(roomId, userId, query.page, query.limit);
   }
 
+  // (신규) 읽음 처리 엔드포인트
+  @Post('rooms/:id/read')
+  @UseGuards(AuthGuard('jwt'))
+  @HttpCode(204) // 성공 시 내용 없이 204 No Content 반환
+  async markAsRead(
+    @Param('id') roomId: string,
+    @Req() req: RequestWithUser,
+  ): Promise<void> {
+    const userId = req.user.id;
+    await this.chatService.markAsRead(roomId, userId);
+  }
+
+  // (신규) 전체 안 읽은 메시지 수 조회 엔드포인트
+  @Get('unread-count')
+  @UseGuards(AuthGuard('jwt'))
+  async getUnreadCount(@Req() req: RequestWithUser) {
+    const userId = req.user.id;
+    const count = await this.chatService.getTotalUnreadCount(userId);
+    return { unreadCount: count };
+  }
+
+  // getMyRooms 반환 타입 수정
   @Get('my-rooms')
-  @UseGuards(AuthGuard('jwt')) // JWT 인증 가드로 보호
-  async getMyRooms(@Req() req: RequestWithUser) {
-    const user = req.user; // 'as User' 타입 단언이 더 이상 필요 없습니다.
-    return this.chatService.getRoomsForUser(user.id);
+  @UseGuards(AuthGuard('jwt'))
+  async getMyRooms(@Req() req: RequestWithUser): Promise<any[]> {
+    // 반환 타입 수정
+    const userId = req.user.id;
+    return this.chatService.getRoomsForUser(userId);
   }
 
   @Get('rooms/:id')

--- a/BackendServer/src/chat/chat.gateway.ts
+++ b/BackendServer/src/chat/chat.gateway.ts
@@ -66,7 +66,6 @@ export class ChatGateway {
 
   @SubscribeMessage('sendMessage')
   async handleSendMessage(
-    // 클라이언트가 보낸 payload. senderName을 추가로 받습니다.
     @MessageBody()
     payload: {
       roomId: string;
@@ -77,14 +76,17 @@ export class ChatGateway {
     // 1. 받은 메시지를 DB에 저장합니다.
     const savedMessage = await this.chatService.saveMessage(payload);
 
-    // 2. [수정] 저장된 메시지를 id로 다시 조회하여 sender 관계를 포함시킵니다.
+    // 2. 저장된 메시지를 id로 다시 조회하여 sender 관계를 포함시킵니다.
     const messageWithSender = await this.msgRepo.findOne({
       where: { id: savedMessage.id },
-      relations: ['sender'], // 'sender' 관계(User 정보)를 함께 로드
+      relations: ['sender'],
     });
 
-    // 3. 해당 방의 모든 클라이언트에게 'sender' 정보가 포함된 메시지 객체를 보냅니다.
+    // 3. 해당 방의 모든 클라이언트에게 새 메시지를 보냅니다.
     this.server.to(payload.roomId).emit('newMessage', messageWithSender);
+
+    // 4. ✨(신규) 해당 방의 클라이언트들에게 안 읽은 카운트를 갱신하라는 신호를 보냅니다.
+    this.server.to(payload.roomId).emit('unreadCountUpdated');
   }
 
   @SubscribeMessage('getHistory')

--- a/BackendServer/src/chat/chat.module.ts
+++ b/BackendServer/src/chat/chat.module.ts
@@ -8,10 +8,11 @@ import { Message } from './entities/message.entity';
 import { Room } from './entities/room.entity';
 import { UserRoom } from './entities/user-room.entity';
 import { UserModule } from '../auth/user/user.module';
+import { UserMessageRead } from './entities/user-message-read.entity'; // 추가
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Message, Room, UserRoom]), // ← 이 줄이 반드시 필요
+    TypeOrmModule.forFeature([Message, Room, UserRoom, UserMessageRead]), // ← 이 줄이 반드시 필요
     UserModule,
   ],
   providers: [ChatService, ChatGateway],

--- a/BackendServer/src/chat/chat.service.ts
+++ b/BackendServer/src/chat/chat.service.ts
@@ -1,3 +1,4 @@
+// src/chat/chat.service.ts
 import {
   Injectable,
   Logger,
@@ -11,8 +12,8 @@ import { Room } from './entities/room.entity';
 import { UserRoom } from './entities/user-room.entity';
 import { Message } from './entities/message.entity';
 import { RoomType } from './dto/create-room.dto';
+import { UserMessageRead } from './entities/user-message-read.entity'; // 추가
 
-// src/chat/chat.service.ts
 @Injectable()
 export class ChatService {
   private readonly logger = new Logger(ChatService.name);
@@ -22,8 +23,11 @@ export class ChatService {
     @InjectRepository(Message) private msgRepo: Repository<Message>,
     @InjectRepository(UserRoom) private urRepo: Repository<UserRoom>,
     @InjectRepository(UserRoom) private userRoomRepo: Repository<UserRoom>,
+    @InjectRepository(UserMessageRead)
+    private readRepo: Repository<UserMessageRead>, // 추가
   ) {}
 
+  // ... createRoom ...
   async createRoom(
     name: string,
     type: RoomType,
@@ -35,22 +39,20 @@ export class ChatService {
       type,
     });
     const savedRoom = await this.roomRepo.save(room);
-
-    // 만약 creatorId가 인자로 전달되었다면, 해당 유저를 방에 참여시킵니다.
     if (creatorId) {
       await this.joinRoom(creatorId, savedRoom.id);
     }
-
     return savedRoom;
   }
 
   // 2) 방 참여 (UserRoom 레코드 생성)
   async joinRoom(id: string, roomId: string): Promise<UserRoom> {
-    const ur = this.urRepo.create({ id, roomId });
-    return this.urRepo.save(ur);
+    const ur = this.userRoomRepo.create({ id, roomId });
+    return this.userRoomRepo.save(ur);
   }
 
   // 3) 메시지 저장
+  // ... saveMessage ...
   async saveMessage(dto: {
     roomId: string;
     senderId: string;
@@ -67,37 +69,34 @@ export class ChatService {
   }
 
   // 4) 방 내 대화 이력 조회 (페이징) - 수정된 함수
+  // ... getHistory ...
   async getHistory(
     roomId: string,
-    id: string,
+    userId: string,
     page = 1,
     limit = 20,
   ): Promise<Message[]> {
-    // 1. 현재 사용자가 이 방에 참여한 정보를 찾습니다.
-    const userRoom = await this.userRoomRepo.findOneBy({ roomId, id });
-
-    // 2. 만약 어떤 이유로든 참여 정보가 없다면, 빈 배열을 반환합니다.
+    const userRoom = await this.userRoomRepo.findOneBy({ roomId, id: userId });
     if (!userRoom) {
-      return [];
+      throw new ForbiddenException('You are not a member of this room.');
     }
-
-    // 3. 사용자의 참여 시간(joinedAt) 이후에 생성된 메시지만 조회합니다.
+    await this.markAsRead(roomId, userId);
     return this.msgRepo.find({
       where: {
         roomId,
-        createdAt: MoreThan(userRoom.joinedAt), // [수정] 사용자의 참여 시간보다 최신인 메시지만 필터링
+        createdAt: MoreThan(userRoom.joinedAt),
       },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
-      relations: ['sender'], // [추가] 메시지 보낸 사람의 정보를 함께 가져오도록 설정
+      relations: ['sender'],
     });
   }
 
   // 5) 방 나가기
   async leaveRoom(id: string, roomId: string): Promise<void> {
     // 1. 사용자를 방에서 내보냅니다 (UserRoom 레코드 삭제).
-    await this.urRepo.delete({ id, roomId });
+    await this.userRoomRepo.delete({ id, roomId });
     this.logger.log(`User ${id} left room ${roomId}`);
 
     // 2. 방에 남은 인원 수를 확인합니다.
@@ -121,16 +120,106 @@ export class ChatService {
     });
   }
 
-  async getRoomsForUser(id: string): Promise<Room[]> {
-    // 1. user_room 테이블에서 해당 유저가 속한 모든 방의 정보를 찾습니다.
-    // 2. 'room' 관계를 함께 로드하여 각 방의 상세 정보(이름 등)를 가져옵니다.
+  async getRoomsForUser(userId: string): Promise<any[]> {
+    // 반환 타입 수정
     const userRooms = await this.userRoomRepo.find({
-      where: { id },
+      where: { id: userId },
       relations: ['room', 'room.userRooms', 'room.userRooms.user'],
+      order: { room: { lastMessageAt: 'DESC' } },
     });
 
-    // 3. UserRoom 엔티티 배열에서 Room 엔티티만 추출하여 반환합니다.
-    return userRooms.map((userRoom) => userRoom.room);
+    if (userRooms.length === 0) return [];
+
+    const roomIds = userRooms.map((ur) => ur.roomId);
+
+    // ✨ (오류 수정) getRawMany()의 결과 타입을 명시해줍니다.
+    interface UnreadCountResult {
+      roomId: string;
+      unreadCount: string; // COUNT 결과는 문자열로 반환됩니다.
+    }
+
+    // 각 방의 안 읽은 메시지 수를 한 번의 쿼리로 가져옵니다.
+    const unreadCounts = await this.msgRepo
+      .createQueryBuilder('message')
+      .leftJoin(
+        UserMessageRead,
+        'read',
+        'read.messageId = message.id AND read.userId = :userId',
+        { userId },
+      )
+      .where('message.roomId IN (:...roomIds)', { roomIds })
+      .andWhere('message.senderId != :userId', { userId }) // 내가 보낸 메시지는 제외
+      .andWhere('read.userId IS NULL')
+      .select('message.roomId', 'roomId')
+      .addSelect('COUNT(message.id)', 'unreadCount')
+      .groupBy('message.roomId')
+      .getRawMany<UnreadCountResult>();
+
+    // lint 경고 해결 및 가독성 향상
+    const unreadCountMap = new Map(
+      unreadCounts.map((item) => [item.roomId, parseInt(item.unreadCount, 10)]),
+    );
+
+    return userRooms.map((userRoom) => ({
+      ...userRoom.room,
+      unreadCount: unreadCountMap.get(userRoom.roomId) || 0,
+    }));
+  }
+
+  // (신규) 특정 방의 메시지 읽음 처리 메서드
+  async markAsRead(roomId: string, userId: string): Promise<void> {
+    interface UnreadMessageId {
+      id: string;
+    }
+    // 1. 해당 방에서 내가 보내지 않고 아직 읽지 않은 모든 메시지 ID를 찾습니다.
+    const unreadMessages = await this.msgRepo
+      .createQueryBuilder('message')
+      .leftJoin(
+        UserMessageRead,
+        'read',
+        'read.messageId = message.id AND read.userId = :userId',
+        { userId },
+      )
+      .where('message.roomId = :roomId', { roomId })
+      .andWhere('message.senderId != :userId', { userId })
+      .andWhere('read.userId IS NULL')
+      .select('message.id', 'id')
+      .getRawMany<UnreadMessageId>();
+
+    const messageIdsToRead = unreadMessages.map((m) => m.id);
+
+    if (messageIdsToRead.length === 0) return;
+
+    // 2. 찾아낸 메시지 ID들을 UserMessageRead 테이블에 한 번에 삽입합니다.
+    const readRecords = messageIdsToRead.map((messageId) => ({
+      userId,
+      messageId,
+      readAt: new Date(),
+    }));
+
+    await this.readRepo.upsert(readRecords, ['userId', 'messageId']);
+  }
+
+  // (신규) 전체 안 읽은 메시지 수 조회
+  async getTotalUnreadCount(userId: string): Promise<number> {
+    return this.msgRepo
+      .createQueryBuilder('message')
+      .leftJoin(
+        UserMessageRead,
+        'read',
+        'read.messageId = message.id AND read.userId = :userId',
+        { userId },
+      )
+      .leftJoin(
+        UserRoom,
+        'ur',
+        'ur.roomId = message.roomId AND ur.id = :userId',
+        { userId },
+      )
+      .where('ur.id IS NOT NULL') // 내가 참여한 방의 메시지만 카운트
+      .andWhere('message.senderId != :userId', { userId }) // 내가 보낸 메시지는 제외
+      .andWhere('read.userId IS NULL')
+      .getCount();
   }
 
   async getOrCreatePrivateRoom(

--- a/BackendServer/src/chat/entities/message.entity.ts
+++ b/BackendServer/src/chat/entities/message.entity.ts
@@ -1,14 +1,20 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, Index, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+  JoinColumn,
+} from 'typeorm';
 import { Room } from './room.entity';
 import { User } from '../../auth/user/user.entity';
-
 
 export enum MessageType {
   TEXT = 'TEXT',
   IMAGE = 'IMAGE',
   FILE = 'FILE',
 }
-
 
 @Entity('message')
 @Index(['roomId', 'createdAt'])
@@ -19,14 +25,14 @@ export class Message {
   @Column({ name: 'room_id', type: 'uuid' })
   roomId: string;
 
-  @ManyToOne(() => Room, room => room.messages, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Room, (room) => room.messages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'room_id' })
   room: Room;
 
   @Column({ name: 'sender', type: 'uuid' })
   senderId: string;
 
-  @ManyToOne(() => User, user => user.messages, { onDelete: 'SET NULL' })
+  @ManyToOne(() => User, (user) => user.messages, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'sender' })
   sender: User;
 

--- a/BackendServer/src/chat/entities/user-message-read.entity.ts
+++ b/BackendServer/src/chat/entities/user-message-read.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../auth/user/user.entity';
+import { Message } from './message.entity';
+
+@Entity('user_message_read')
+export class UserMessageRead {
+  @PrimaryColumn({ name: 'user_id' })
+  userId: string;
+
+  @PrimaryColumn({ name: 'message_id' })
+  messageId: string;
+
+  @CreateDateColumn({ name: 'read_at' })
+  readAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Message, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'message_id' })
+  message: Message;
+}

--- a/BackendServer/src/main.ts
+++ b/BackendServer/src/main.ts
@@ -28,7 +28,7 @@ async function bootstrap() {
   app.enableCors({
     origin: allowedOrigins, // ⬅️ origin을 배열로 전달
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-    credentials: true, 
+    credentials: true,
     allowedHeaders: 'Content-Type, Accept, Authorization',
     exposedHeaders: 'Authorization',
   });

--- a/WebFrontend/src/App.tsx
+++ b/WebFrontend/src/App.tsx
@@ -1,3 +1,5 @@
+// WebFrontend/src/App.tsx 
+
 import { useEffect } from "react";
 import AppRouter from "./routes/AppRouter";
 import "./App.css";
@@ -6,10 +8,14 @@ import { useAuthStore } from "./stores/authStore";
 import { Toaster } from "react-hot-toast";
 import { useChatStore } from "./stores/chatStore";
 import { useConfigStore } from './stores/useConfigStore';
+import axiosInstance from "./services/axiosInstance"; // ✨ axiosInstance import 추가
+
+interface MyRoom { id: string; } // ✨ 간단한 타입 정의
 
 function App() {
   const fetchConfig = useConfigStore((state) => state.fetchConfig);
-  const setToken = useAuthStore((state) => state.actions.setToken);
+  const { user, actions: { setToken } } = useAuthStore(); // ✨ user 상태 가져오기
+  const { initializeSocketListeners, disconnectSocket, fetchTotalUnreadCount } = useChatStore(); // ✨ chatStore 함수 가져오기
 
   // 환경변수 설정
   useEffect(() => {
@@ -18,7 +24,7 @@ function App() {
 
   // 1. React Native 등 외부로부터 토큰을 받기 위한 useEffect (유지)
   useEffect(() => {
-    const handleMessage = (event: any) => {
+    const handleMessage = (event: MessageEvent) => {
       try {
         const message = JSON.parse(event.data);
         if (message.type === "SET_TOKEN" && message.token) {
@@ -30,27 +36,53 @@ function App() {
     };
 
     window.addEventListener("message", handleMessage);
-    document.addEventListener("message", handleMessage);
+    // document.addEventListener("message", handleMessage);
 
     return () => {
       window.removeEventListener("message", handleMessage);
-      document.removeEventListener("message", handleMessage);
+      // document.removeEventListener("message", handleMessage);
     };
   }, [setToken]);
 
-  // 2. 채팅 소켓 연결 및 해제를 위한 useEffect (이 블록 하나만 사용)
+  // ✨ 로그인 상태에 따라 소켓과 데이터를 관리하는 useEffect (이것 하나로 통합)
   useEffect(() => {
-    // chatStore에서 필요한 함수들을 가져옵니다.
-    const { initializeSocketListeners, disconnectSocket } = useChatStore.getState();
-    
-    // 소켓 연결 및 리스너 등록
-    initializeSocketListeners();
+    if (user) {
+      initializeSocketListeners();
+      fetchTotalUnreadCount();
 
-    // 컴포넌트가 사라질 때(cleanup) 소켓 연결을 끊습니다.
-    return () => {
-      disconnectSocket();
-    };
-  }, []); // 빈 배열[]: 앱이 처음 실행될 때 딱 한 번만 실행되도록 보장
+      // ✨ 소켓이 연결된 후에 실행될 로직
+      const joinAllMyRooms = async () => {
+        try {
+          // 1. 내가 속한 모든 방 목록을 가져옵니다.
+          const response = await axiosInstance.get<MyRoom[]>('chat/my-rooms');
+          const myRooms = response.data;
+          
+          // 2. socket 인스턴스를 스토어에서 직접 가져옵니다.
+          const chatSocket = useChatStore.getState().socket;
+
+          if (chatSocket && myRooms.length > 0) {
+            console.log('Joining all my rooms:', myRooms.map(r => r.id));
+            // 3. 각 방에 대해 'joinRoom' 이벤트를 보냅니다.
+            myRooms.forEach(room => {
+              chatSocket.emit('joinRoom', { id: user.id, roomId: room.id });
+            });
+          }
+        } catch (error) {
+          console.error("Failed to fetch and join my rooms", error);
+        }
+      };
+
+      // ✨ 소켓 연결이 확인되면 방 조인 로직을 실행
+      // 'connect' 이벤트를 한 번만 수신하도록 `socket.once` 사용
+      useChatStore.getState().socket.once('connect', joinAllMyRooms);
+      
+      return () => {
+        // cleanup 시 리스너 제거
+        useChatStore.getState().socket.off('connect', joinAllMyRooms);
+        disconnectSocket();
+      };
+    }
+  }, [user, initializeSocketListeners, disconnectSocket, fetchTotalUnreadCount]);
 
   return (
     <div className=""> 

--- a/WebFrontend/src/components/layout/MainFooter.tsx
+++ b/WebFrontend/src/components/layout/MainFooter.tsx
@@ -36,6 +36,7 @@ interface MainFooterProps {
   onVinylClick?: () => void;
   onChatClick?: () => void;
   onMyPageClick?: () => void;
+  totalUnreadCount?: number;
 }
 
 const MainFooter: React.FC<MainFooterProps> = ({
@@ -45,6 +46,7 @@ const MainFooter: React.FC<MainFooterProps> = ({
   onVinylClick,
   onChatClick,
   onMyPageClick,
+  totalUnreadCount = 0,
 }) => {
   return (
     <footer
@@ -70,12 +72,22 @@ const MainFooter: React.FC<MainFooterProps> = ({
         active={currentPath.startsWith("/vinyl")}
         onClick={onVinylClick}
       />
-      <NavItem
-        iconName="chat"
-        label="채팅"
-        active={currentPath.startsWith("/chat")}
-        onClick={onChatClick}
-      />
+      <div className="relative flex-1">
+        <NavItem
+          iconName="chat"
+          label="채팅"
+          active={currentPath.startsWith("/chat")}
+          onClick={onChatClick}
+        />
+        {/* ✨ 여기에 배지 코드를 넣습니다. */}
+        {totalUnreadCount > 0 && (
+          <div 
+            className="absolute top-1 right-[28%] flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs text-white pointer-events-none"
+          >
+            {totalUnreadCount > 9 ? '9+' : totalUnreadCount}
+          </div>
+        )}
+      </div>
       <NavItem
         iconName="user"
         label="마이"

--- a/WebFrontend/src/components/layout/MainLayout.tsx
+++ b/WebFrontend/src/components/layout/MainLayout.tsx
@@ -12,9 +12,10 @@ interface LayoutProps {
   onCategoryClick?: () => void;
   onSearchClick?: () => void;
   onNotificationClick?: () => void;
+  totalUnreadCount?: number;
 }
 
-const Layout: React.FC<LayoutProps> = ({ children }) => {
+const Layout: React.FC<LayoutProps> = ({ children, totalUnreadCount }) => {
   const navigate = useNavigate();
   const user = useAuthStore((state) => state.user); // user 정보 가져오기
   const location = useLocation();
@@ -52,6 +53,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         onVinylClick={handleGoToVinyl}
         onChatClick={handleGoToChat}
         onMyPageClick={handleGoToMyPage}
+        totalUnreadCount={totalUnreadCount}
       />
     </div>
   );

--- a/WebFrontend/src/components/layout/PostLayout.tsx
+++ b/WebFrontend/src/components/layout/PostLayout.tsx
@@ -10,9 +10,10 @@ interface LayoutProps {
   children: React.ReactNode;
   bgClassName?: string;
   onSearchClick?: () => void;
+  totalUnreadCount?: number;
 }
 
-const PostLayout: React.FC<LayoutProps> = ({ children, bgClassName = "bg-brand-frame", onSearchClick }) => {
+const PostLayout: React.FC<LayoutProps> = ({ children, bgClassName = "bg-brand-frame", onSearchClick, totalUnreadCount }) => {
   const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
   const location = useLocation();
@@ -52,6 +53,7 @@ const PostLayout: React.FC<LayoutProps> = ({ children, bgClassName = "bg-brand-f
         onVinylClick={handleGoToVinyl}
         onChatClick={handleGoToChat}
         onMyPageClick={handleGoToMyPage}
+        totalUnreadCount={totalUnreadCount}
       />
     </div>
   );

--- a/WebFrontend/src/components/layout/UserPageLayout.tsx
+++ b/WebFrontend/src/components/layout/UserPageLayout.tsx
@@ -9,9 +9,10 @@ interface MyPageLayoutProps {
   children: React.ReactNode;
   onSettingsClick?: () => void;
   onSearchClick?: () => void;
+  totalUnreadCount?: number;
 }
 
-const MyPageLayout: React.FC<MyPageLayoutProps> = ({ children, onSettingsClick, onSearchClick }) => {
+const MyPageLayout: React.FC<MyPageLayoutProps> = ({ children, onSettingsClick, onSearchClick, totalUnreadCount }) => {
   const navigate = useNavigate();
   const { pathname } = useLocation(); 
   const user = useAuthStore((state) => state.user);
@@ -33,6 +34,7 @@ const MyPageLayout: React.FC<MyPageLayoutProps> = ({ children, onSettingsClick, 
         onVinylClick={() => navigate('/vinyl')}
         onChatClick={() => navigate('/chat')}
         onMyPageClick={handleGoToMyPage}
+        totalUnreadCount={totalUnreadCount}
       />
     </div>
   );

--- a/WebFrontend/src/components/layout/pages/ensemble/EnsembleDetail.tsx
+++ b/WebFrontend/src/components/layout/pages/ensemble/EnsembleDetail.tsx
@@ -19,6 +19,7 @@ interface RecruitEnsembleProps {
   onDelete?: () => void;
   applicationEnsembleList: ApplicationEnsemble[];
   isApplied: boolean;
+  totalUnreadCount?: number;
 }
 
 const skillLevelColorMap: Record<number, string> = {
@@ -36,9 +37,10 @@ export const RecruitEnsembleDetail: React.FC<RecruitEnsembleProps> = ({
   onDelete,
   applicationEnsembleList,
   isApplied,
+  totalUnreadCount,
 }) => {
   return (
-    <PostLayout bgClassName="bg-brand-inverse">
+    <PostLayout totalUnreadCount={totalUnreadCount} bgClassName="bg-brand-inverse">
       <div className="relative mx-auto px-4 w-full">
         {isOwner && (
           <div className="absolute top-1 right-4 z-10">

--- a/WebFrontend/src/components/layout/pages/practiceRoom/PracticeRoomDetailForm.tsx
+++ b/WebFrontend/src/components/layout/pages/practiceRoom/PracticeRoomDetailForm.tsx
@@ -15,6 +15,7 @@ interface PracticeRoomDetailProps {
   onEdit?: () => void;
   onComplete?: () => void;
   onDelete?: () => void;
+  totalUnreadCount?: number;
 }
 
 const styles = statusStyleMap["예약하기"];
@@ -24,9 +25,10 @@ export const PracticeRoomDetail: React.FC<PracticeRoomDetailProps> = ({
   isOwner = false,
   onEdit,
   onDelete,
+  totalUnreadCount,
 }) => {
   return (
-    <PostLayout bgClassName="bg-brand-inverse">
+    <PostLayout totalUnreadCount={totalUnreadCount} bgClassName="bg-brand-inverse">
       <div className="mx-auto p-4 w-full">
         <div className="relative">
         {/* 이미지 섹션 */}

--- a/WebFrontend/src/components/layout/pages/practiceRoom/PracticeRoomForm.tsx
+++ b/WebFrontend/src/components/layout/pages/practiceRoom/PracticeRoomForm.tsx
@@ -15,6 +15,7 @@ interface PracticeRoomFormProps {
   errorMessage: string | null;
   submitButtonText: string;
   loadingButtonText: string;
+  totalUnreadCount?: number;
 }
 
 // 공통 입력 필드 스타일

--- a/WebFrontend/src/pages/chat/ChatListPage.tsx
+++ b/WebFrontend/src/pages/chat/ChatListPage.tsx
@@ -1,9 +1,8 @@
-// src/pages/ChatListPage.tsx (수정된 최종본)
-
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import axiosInstance from "../../services/axiosInstance";
 import { useAuthStore } from "../../stores/authStore";
+import { useChatStore } from "../../stores/chatStore";
 
 // 공통 컴포넌트를 import 합니다.
 import PostLayout from "@/components/layout/PostLayout";
@@ -26,6 +25,7 @@ interface ChatRoom {
   name?: string;
   type: "PRIVATE" | "GROUP";
   userRooms: UserRoom[];
+  unreadCount: number;
 }
 
 const ChatListPage: React.FC = () => {
@@ -34,10 +34,11 @@ const ChatListPage: React.FC = () => {
   const [newRoomName, setNewRoomName] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
   const [isSearchOverlayOpen, setIsSearchOverlayOpen] = useState(false);
 
   const { user } = useAuthStore();
+  // ✨ 스토어에서 전체 안 읽은 메시지 수 관련 상태와 함수 가져오기
+  const { totalUnreadCount} = useChatStore();
 
   useEffect(() => {
     if (!user) {
@@ -57,7 +58,7 @@ const ChatListPage: React.FC = () => {
       }
     };
     fetchChatRooms();
-  }, [user]);
+  }, [user, totalUnreadCount]);
 
   const handleCreateRoom = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -69,39 +70,38 @@ const ChatListPage: React.FC = () => {
       });
       setNewRoomName("");
       alert(`'${response.data.name}' 방이 생성되었습니다!`);
-      const roomsResponse =
-        await axiosInstance.get<ChatRoom[]>("chat/my-rooms");
+      const roomsResponse = await axiosInstance.get<ChatRoom[]>("chat/my-rooms");
       setRooms(roomsResponse.data);
     } catch (err) {
       alert("채팅방 생성에 실패했습니다.");
     }
   };
+
   const handleEnterRoom = (roomId: string) => {
     navigate(`/chat/${roomId}`);
   };
 
-  if (loading)
+  if (loading) {
     return (
       <PostLayout>
-        <div className="p-4 text-center">
-          채팅방 정보를 불러오고 있습니다...
-        </div>
+        <div className="p-4 text-center">채팅방 정보를 불러오고 있습니다...</div>
       </PostLayout>
     );
-  if (error)
+  }
+
+  if (error) {
     return (
       <PostLayout>
-        <div className="p-4 text-center text-brand-error-text">
-          에러: {error}
-        </div>
+        <div className="p-4 text-center text-brand-error-text">에러: {error}</div>
       </PostLayout>
     );
+  }
 
   return (
-    // PostLayout을 사용하고, 배경색을 흰색으로 지정합니다.
     <PostLayout
       bgClassName="bg-brand-frame"
       onSearchClick={() => setIsSearchOverlayOpen(true)}
+      totalUnreadCount={totalUnreadCount} // 필요 시 PostLayout에 전달하여 헤더 등에 사용
     >
       <div className="p-4">
         {/* 그룹 채팅방 생성 폼 */}
@@ -127,82 +127,57 @@ const ChatListPage: React.FC = () => {
             rooms.map((room) => {
               const isPrivate = room.type === "PRIVATE";
               const participants = room.userRooms?.map((ur) => ur.user) || [];
-              const chatPartner = isPrivate
-                ? participants.find((p) => p.id !== user?.id)
-                : null;
-
-              const roomName = isPrivate
-                ? chatPartner?.username || "알 수 없는 사용자"
-                : room.name;
-              const avatarAlt = isPrivate
-                ? chatPartner?.username || "?"
-                : room.name?.charAt(0) || "G";
+              const chatPartner = isPrivate ? participants.find((p) => p.id !== user?.id) : null;
+              const roomName = isPrivate ? chatPartner?.username || "알 수 없는 사용자" : room.name;
+              const avatarAlt = isPrivate ? chatPartner?.username || "?" : room.name?.charAt(0) || "G";
 
               return (
                 <div
                   key={room.id}
-                  className="flex items-center justify-between p-3 transition-colors rounded-card bg-brand-default hover:bg-gray-200 cursor-pointer"
+                  // ✨ 안 읽은 메시지가 있으면 배경색과 폰트 굵기를 다르게 표시
+                  className={`flex items-center justify-between p-3 transition-colors rounded-card ${room.unreadCount > 0 ? "bg-blue-50 font-semibold" : "bg-brand-default"} hover:bg-gray-200 cursor-pointer`}
                   onClick={() => handleEnterRoom(room.id)}
                 >
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 overflow-hidden">
                     {/* 아바타 표시 */}
                     {isPrivate ? (
-                      <Avatar
-                        src={
-                          chatPartner?.profileUrl ||
-                          DEFAULT_IMAGES.PROFILE
-                        }
-                        alt={avatarAlt}
-                        size={48}
-                      />
+                      <Avatar src={chatPartner?.profileUrl || DEFAULT_IMAGES.PROFILE} alt={avatarAlt} size={48} />
                     ) : (
-                      <div className="relative flex w-12 h-12">
+                      <div className="relative flex-shrink-0 flex w-12 h-12">
                         {participants.slice(0, 2).map((p, index) => (
-                          <div
-                            key={p.id}
-                            className={`absolute ${index === 0 ? "top-0 left-0 z-10" : "bottom-0 right-0"}`}
-                          >
-                            <Avatar
-                              src={
-                                p.profileUrl ||
-                                DEFAULT_IMAGES.PROFILE
-                              }
-                              alt={p.username}
-                              size={32}
-                            />
+                          <div key={p.id} className={`absolute ${index === 0 ? "top-0 left-0 z-10" : "bottom-0 right-0"}`}>
+                            <Avatar src={p.profileUrl || DEFAULT_IMAGES.PROFILE} alt={p.username} size={32} />
                           </div>
                         ))}
                       </div>
                     )}
                     {/* 채팅방 이름 및 정보 */}
-                    <div>
-                      <p className="text-caption-bold text-brand-text-primary">
-                        {roomName}
-                      </p>
+                    <div className="truncate">
+                      <p className="text-caption-bold text-brand-text-primary truncate">{roomName}</p>
                       {!isPrivate && (
-                        <p className="text-footnote text-brand-gray">
-                          {participants.length}명 참여중
-                        </p>
+                        <p className="text-footnote text-brand-gray">{participants.length}명 참여중</p>
                       )}
                     </div>
                   </div>
+
+                  {/* ✨ 안 읽은 메시지 수 배지 표시 */}
+                  {room.unreadCount > 0 && (
+                    <div className="ml-2 flex-shrink-0 w-6 h-6 flex items-center justify-center bg-brand-primary text-white text-xs rounded-full">
+                      {room.unreadCount}
+                    </div>
+                  )}
                 </div>
               );
             })
           ) : (
             <div className="py-20 text-center text-brand-gray">
               <p>참여하고 있는 채팅방이 없습니다.</p>
-              <p className="text-footnote">
-                새로운 그룹 채팅방을 만들어보세요!
-              </p>
+              <p className="text-footnote">새로운 그룹 채팅방을 만들어보세요!</p>
             </div>
           )}
         </div>
       </div>
-      <SearchOverlay
-        isOpen={isSearchOverlayOpen}
-        onClose={() => setIsSearchOverlayOpen(false)}
-      />
+      <SearchOverlay isOpen={isSearchOverlayOpen} onClose={() => setIsSearchOverlayOpen(false)} />
     </PostLayout>
   );
 };

--- a/WebFrontend/src/pages/chat/ChatRoomPage.tsx
+++ b/WebFrontend/src/pages/chat/ChatRoomPage.tsx
@@ -1,5 +1,3 @@
-// WebFrontend/src/pages/chat/ChatRoomPage.tsx
-
 import React, { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { motion, useMotionValue } from "framer-motion";
@@ -21,7 +19,7 @@ import { IoChevronDown } from "react-icons/io5";
 import axiosInstance from "../../services/axiosInstance";
 import { DEFAULT_IMAGES } from "@/constants/images";
 
-// 시간 포맷팅을 위한 간단한 헬퍼 함수 (컴포넌트 외부에 추가)
+// 시간 포맷팅을 위한 간단한 헬퍼 함수
 const formatTime = (dateString: string | Date) => {
   const date = new Date(dateString);
   return date.toLocaleTimeString("ko-KR", {
@@ -35,10 +33,10 @@ const ChatRoomPage: React.FC = () => {
   const { roomId } = useParams<{ roomId: string }>();
   const navigate = useNavigate();
 
-  // --- 스토어에서 상태와 액션 가져오기 ---
   const { user } = useAuthStore();
   const id = user?.id;
 
+  // ✨ 스토어에서 fetchTotalUnreadCount 액션 가져오기
   const {
     isConnected,
     messages,
@@ -55,6 +53,7 @@ const ChatRoomPage: React.FC = () => {
     leaveCurrentRoom,
     openModal,
     closeModal,
+    fetchTotalUnreadCount, // ✨ 추가
   } = useChatStore();
 
   const goToUserProfile = () => {
@@ -63,85 +62,68 @@ const ChatRoomPage: React.FC = () => {
     }
   };
 
-  // --- 컴포넌트 로컬 상태 ---
   const [newMessage, setNewMessage] = useState("");
   const [inviteeId, setInviteeId] = useState("");
   const chatEndRef = useRef<HTMLDivElement>(null);
   const dragX = useMotionValue(0);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
-
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
   const handleScroll = () => {
     const container = scrollContainerRef.current;
-    // 스크롤이 맨 위로 올라갔고, 로딩 중이 아니며, 더 불러올 메시지가 있을 때
     if (container) {
-      const isScrolledUp =
-        container.scrollHeight - container.scrollTop - container.clientHeight >
-        100;
-      setShowScrollToBottom(isScrolledUp); // 상태 업데이트
-
-      if (container && container.scrollTop === 0 && !isLoadingMore && hasMore) {
-        // 이전 스크롤 높이를 기록
+      const isScrolledUp = container.scrollHeight - container.scrollTop - container.clientHeight > 100;
+      setShowScrollToBottom(isScrolledUp);
+      if (container.scrollTop === 0 && !isLoadingMore && hasMore) {
         const prevScrollHeight = container.scrollHeight;
-
         loadMoreMessages().then(() => {
-          // 비동기 로딩 후 스크롤 위치 조정
           if (scrollContainerRef.current) {
             const newScrollHeight = scrollContainerRef.current.scrollHeight;
-            scrollContainerRef.current.scrollTop =
-              newScrollHeight - prevScrollHeight;
+            scrollContainerRef.current.scrollTop = newScrollHeight - prevScrollHeight;
           }
         });
       }
     }
   };
-  // --- 컴포넌트 생명주기와 스토어 액션 연결 ---
-  useEffect(() => {
-    // 필수 정보가 없으면 실행을 중단합니다.
-    if (!roomId || !user) {
-      return;
-    }
 
-    // ✅ 접근 권한 확인 및 방 초기화를 위한 비동기 함수
+  useEffect(() => {
+    if (!roomId || !user) return;
+
     const validateAndInitialize = async () => {
       try {
-        // 1. 백엔드 API를 호출하여 현재 유저가 이 채팅방에 접근할 권한이 있는지 확인합니다.
+        // 1. 방 접근 권한 확인
         await axiosInstance.get(`/chat/rooms/${roomId}`);
+        
+        // ✨ 2. 방에 들어오자마자 메시지를 읽음으로 처리하는 API 호출
+        await axiosInstance.post(`/chat/rooms/${roomId}/read`);
+        
+        // ✨ 3. 읽음 처리 후, 전체 안 읽은 메시지 수를 다시 가져와 전역 상태를 업데이트
+        await fetchTotalUnreadCount();
 
-        // 2. 권한 확인이 성공하면, 소켓 연결 상태를 확인하고 방 초기화를 진행합니다.
         if (isConnected) {
           initializeRoom(roomId);
         }
       } catch (error) {
-        // 3. 권한이 없거나 방이 존재하지 않으면 에러가 발생합니다.
         console.error("접근 권한이 없거나 존재하지 않는 채팅방입니다.", error);
         alert("접근할 수 없는 채팅방입니다.");
-        navigate("/main"); // 사용자를 메인 페이지로 리다이렉트합니다.
+        navigate("/main");
       }
     };
 
-    // 위에서 정의한 비동기 함수를 호출합니다.
     validateAndInitialize();
 
-    // 컴포넌트가 사라질 때 채팅 관련 리소스를 정리하는 cleanup 함수를 반환합니다.
     return () => {
       cleanupRoom();
     };
-  }, [roomId, user, isConnected, navigate, initializeRoom, cleanupRoom]); // 의존성 배열에 navigate 추가
-
-  // 메시지 목록이 변경될 때마다 맨 아래로 스크롤
-  useEffect(() => {
-    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+    // ✨ 의존성 배열에 fetchTotalUnreadCount 추가
+  }, [roomId, user, isConnected, navigate, initializeRoom, cleanupRoom, fetchTotalUnreadCount]);
 
   useEffect(() => {
     if (!isLoadingMore) {
-      // 추가 로딩 시에는 맨 아래로 가지 않도록 함
       chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages.length, isLoadingMore]);
 
-  // --- 핸들러 함수들 ---
   const handleSendMessage = () => {
     if (!newMessage.trim()) return;
     sendMessage(newMessage);
@@ -166,15 +148,11 @@ const ChatRoomPage: React.FC = () => {
     setInviteeId("");
   };
 
-  // 로딩 상태를 더 명확하게 표시
   if (!isConnected || !user) {
     return (
       <div className="flex flex-col h-screen max-w-4xl mx-auto bg-brand-default">
         <header className="flex items-center justify-between p-4 border-b border-gray-200">
-          {/* 헤더 UI는 유지하되, 내용은 로딩 상태로 표시 */}
-          <h2 className="text-subheadline text-brand-text-primary">
-            연결 중...
-          </h2>
+          <h2 className="text-subheadline text-brand-text-primary">연결 중...</h2>
         </header>
         <main className="flex-1 p-4 overflow-y-auto flex justify-center items-center">
           <p>채팅방 정보를 불러오고 있습니다...</p>
@@ -183,43 +161,22 @@ const ChatRoomPage: React.FC = () => {
     );
   }
 
-  // --- JSX (UI 렌더링) ---
   return (
     <div className="flex flex-col h-screen max-w-4xl mx-auto bg-brand-default">
       {/* 헤더 */}
       <header className="flex items-center justify-between p-4 border-b border-gray-200">
-        <button
-          onClick={() => navigate("/chat")}
-          className="p-2 text-brand-gray hover:text-brand-primary"
-        >
+        <button onClick={() => navigate("/chat")} className="p-2 text-brand-gray hover:text-brand-primary">
           <Icon name="back" />
         </button>
-        <button
-          onClick={goToUserProfile}
-          className="flex items-center gap-3 p-2 -ml-2 rounded-lg hover:bg-gray-100"
-          disabled={!chatPartner.id}
-        >
-          <Avatar
-            src={chatPartner.profileUrl || DEFAULT_IMAGES.PROFILE}
-            alt={chatPartner.username}
-            size={32}
-          />
-          <h2 className="text-subheadline text-brand-text-primary">
-            {chatPartner.username}
-          </h2>
+        <button onClick={goToUserProfile} className="flex items-center gap-3 p-2 -ml-2 rounded-lg hover:bg-gray-100" disabled={!chatPartner.id}>
+          <Avatar src={chatPartner.profileUrl || DEFAULT_IMAGES.PROFILE} alt={chatPartner.username} size={32} />
+          <h2 className="text-subheadline text-brand-text-primary">{chatPartner.username}</h2>
         </button>
-
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => openModal("invite")}
-            className="p-2 text-brand-gray hover:text-brand-primary"
-          >
+          <button onClick={() => openModal("invite")} className="p-2 text-brand-gray hover:text-brand-primary">
             <Icon name="addUser" size={22} />
           </button>
-          <button
-            onClick={() => openModal("leave")}
-            className="p-2 text-brand-gray hover:text-brand-error-text"
-          >
+          <button onClick={() => openModal("leave")} className="p-2 text-brand-gray hover:text-brand-error-text">
             <Icon name="exit" />
           </button>
         </div>
@@ -235,47 +192,25 @@ const ChatRoomPage: React.FC = () => {
         dragElastic={0.1}
         dragSnapToOrigin
       >
-        {isLoadingMore && (
-          <div className="text-center p-2 text-brand-gray">
-            이전 메시지를 불러오는 중...
-          </div>
-        )}
+        {isLoadingMore && <div className="text-center p-2 text-brand-gray">이전 메시지를 불러오는 중...</div>}
         <div className="flex flex-col gap-2">
           {messages.map((msg: Message) =>
             msg.isSystem ? (
-              <div
-                key={msg.id}
-                className="self-center px-3 py-1 text-xs text-brand-gray bg-gray-200 rounded-full"
-              >
+              <div key={msg.id} className="self-center px-3 py-1 text-xs text-brand-gray bg-gray-200 rounded-full">
                 {msg.content}
               </div>
             ) : (
               <div key={msg.id}>
                 {msg.senderId === id ? (
-                  // 내가 보낸 메시지
                   <div className="flex w-full justify-end">
-                    <MessageBubble
-                      msg={{ ...msg, time: formatTime(msg.createdAt) }}
-                      currentUserId={id}
-                      dragX={dragX}
-                    />
+                    <MessageBubble msg={{ ...msg, time: formatTime(msg.createdAt) }} currentUserId={id} dragX={dragX} />
                   </div>
                 ) : (
-                  // 상대방이 보낸 메시지
                   <div className="flex items-end gap-2">
-                    <Avatar
-                      src={msg.sender?.profileUrl || DEFAULT_IMAGES.PROFILE}
-                      alt={msg.sender?.username}
-                    />
+                    <Avatar src={msg.sender?.profileUrl || DEFAULT_IMAGES.PROFILE} alt={msg.sender?.username} />
                     <div className="flex flex-col">
-                      <span className="text-sm text-brand-gray mb-1 text-left block">
-                        {msg.sender?.username}
-                      </span>
-                      <MessageBubble
-                        msg={{ ...msg, time: formatTime(msg.createdAt) }}
-                        currentUserId={id}
-                        dragX={dragX}
-                      />
+                      <span className="text-sm text-brand-gray mb-1 text-left block">{msg.sender?.username}</span>
+                      <MessageBubble msg={{ ...msg, time: formatTime(msg.createdAt) }} currentUserId={id} dragX={dragX} />
                     </div>
                   </div>
                 )}
@@ -286,69 +221,41 @@ const ChatRoomPage: React.FC = () => {
         <div ref={chatEndRef} />
         {showScrollToBottom && (
           <button
-            onClick={() =>
-              chatEndRef.current?.scrollIntoView({ behavior: "smooth" })
-            }
-            className="absolute bottom-5 right-5 bg-blue-500 text-white rounded-full p-2 shadow-lg hover:bg-blue-600 focus:outline-none"
+            onClick={() => chatEndRef.current?.scrollIntoView({ behavior: "smooth" })}
+            className="absolute bottom-24 right-5 bg-white text-brand-primary rounded-full p-2 shadow-lg hover:bg-gray-100 focus:outline-none"
             aria-label="Scroll to bottom"
           >
-            <IoChevronDown size={20} />
+            <IoChevronDown size={24} />
           </button>
         )}
       </motion.main>
       {/* 푸터 */}
       <footer className="p-4 bg-white border-t border-gray-200">
         <div className="flex items-end gap-3">
-          <MessageInput
-            value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-          />
-          <button
-            onClick={handleSendMessage}
-            className="flex-shrink-0 p-3 text-white rounded-full bg-brand-primary disabled:bg-brand-disabled"
-            disabled={!newMessage.trim()}
-          >
+          <MessageInput value={newMessage} onChange={(e) => setNewMessage(e.target.value)} onKeyDown={handleKeyDown} />
+          <button onClick={handleSendMessage} className="flex-shrink-0 p-3 text-white rounded-full bg-brand-primary disabled:bg-brand-disabled" disabled={!newMessage.trim()}>
             <Icon name="send" size={20} />
           </button>
         </div>
       </footer>
-
       {/* 모달 렌더링 */}
       {isModalOpen && (
-        <Modal
-          isOpen={isModalOpen}
-          onClose={closeModal}
-          title={modalType === "leave" ? "채팅방 나가기" : "사용자 초대"}
-        >
-          {modalType === "leave" ? (
+        <Modal isOpen={isModalOpen} onClose={closeModal} title={modalType === 'leave' ? '채팅방 나가기' : '사용자 초대'}>
+          {modalType === 'leave' ? (
             <>
               <p className="mb-6">정말로 이 방을 나가시겠습니까?</p>
               <div className="flex justify-end gap-3">
                 <SecondaryButton onClick={closeModal}>취소</SecondaryButton>
-                <PrimaryButton
-                  onClick={confirmLeaveRoom}
-                  className="!w-auto !bg-red-500"
-                >
-                  나가기
-                </PrimaryButton>
+                <PrimaryButton onClick={confirmLeaveRoom} className="!w-auto !bg-red-500">나가기</PrimaryButton>
               </div>
             </>
           ) : (
             <>
               <p className="mb-4">초대할 사용자의 ID를 입력하세요.</p>
-              <TextInput
-                type="text"
-                placeholder="사용자 ID"
-                value={inviteeId}
-                onChange={(e) => setInviteeId(e.target.value)}
-                autoFocus
-              />
+              <TextInput type="text" placeholder="사용자 ID" value={inviteeId} onChange={(e) => setInviteeId(e.target.value)} autoFocus />
               <div className="flex justify-end gap-3 mt-6">
                 <SecondaryButton onClick={closeModal}>취소</SecondaryButton>
-                <PrimaryButton onClick={confirmInviteUser} className="!w-auto">
-                  초대하기
-                </PrimaryButton>
+                <PrimaryButton onClick={confirmInviteUser} className="!w-auto">초대하기</PrimaryButton>
               </div>
             </>
           )}

--- a/WebFrontend/src/pages/community/CommunityFeedPage.tsx
+++ b/WebFrontend/src/pages/community/CommunityFeedPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { useChatStore } from '../../stores/chatStore';
 // import axios from 'axios';
 
 import axiosInstance from "../../services/axiosInstance";
@@ -54,6 +55,7 @@ const deletePost = async (id: number): Promise<void> => {
 const CATEGORIES = ["전체", "자유게시판", "질문/답변", "피드백", "공연홍보"];
 
 const CommunityFeedPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const currentUser = useAuthStore((state) => state.user);
   const [posts, setPosts] = useState<Post[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -160,7 +162,8 @@ const CommunityFeedPage: React.FC = () => {
   };
 
   return (
-    <PostLayout>
+    <PostLayout 
+      totalUnreadCount={totalUnreadCount}>
       <div className="p-4">
         {keyword ? (
           <h2 className="text-xl font-bold mb-4">

--- a/WebFrontend/src/pages/community/CreatePostPage.tsx
+++ b/WebFrontend/src/pages/community/CreatePostPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 import { useAuthStore } from '../../stores/authStore';
 import axiosInstance from '../../services/axiosInstance';
+import { useChatStore } from '../../stores/chatStore';
 
 // Layout & Button Components
 import PostLayout from '@/components/layout/PostLayout';
@@ -31,6 +32,7 @@ const createPost = async (newPostData: CreatePostData) => {
 const CATEGORY_OPTIONS = ['자유게시판', '질문/답변', '피드백', '공연홍보'];
 
 const CreatePostPage: React.FC = () => {
+    const { totalUnreadCount } = useChatStore();
     const navigate = useNavigate();
     const currentUser = useAuthStore((state) => state.user);
 
@@ -66,7 +68,7 @@ const CreatePostPage: React.FC = () => {
     };
 
     return (
-        <PostLayout>
+        <PostLayout totalUnreadCount={totalUnreadCount}>
             <div className="p-4 bg-brand-frame min-h-screen">
                 <header className="mb-6">
                     <h1 className="text-subheadline text-brand-text-primary">새 글 작성</h1>

--- a/WebFrontend/src/pages/community/PostDetailPage.tsx
+++ b/WebFrontend/src/pages/community/PostDetailPage.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { useAuthStore } from "../../stores/authStore";
+import { useChatStore } from '../../stores/chatStore';
 import axiosInstance from "../../services/axiosInstance";
 
 // Layout 및 컴포넌트 import
@@ -60,6 +61,7 @@ const formatDate = (dateString: string) =>
 
 // --- 상세 페이지 컴포넌트 ---
 const PostDetailPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const { id } = useParams<{ id: string }>();
   const currentUser = useAuthStore((state) => state.user);
 
@@ -141,7 +143,10 @@ const PostDetailPage: React.FC = () => {
     return <div className="p-4 text-center">게시물을 찾을 수 없습니다.</div>;
 
   return (
-    <PostLayout bgClassName="text-left bg-brand-frame bg-brand-inverse">
+    <PostLayout 
+      totalUnreadCount={totalUnreadCount} 
+      bgClassName="text-left bg-brand-frame bg-brand-inverse">
+        
       <div className="p-4">
         {/* 게시글 헤더 */}
         <header className="mb-4 pb-4 border-b border-brand-frame">

--- a/WebFrontend/src/pages/ensemble/CreateRecruitEnsemblePage.tsx
+++ b/WebFrontend/src/pages/ensemble/CreateRecruitEnsemblePage.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from '@/services/axiosInstance';
 import { useAuthStore } from '@/stores/authStore';
+import { useChatStore } from '../../stores/chatStore';
 // 1. 공통 폼과 관련 타입들을 components 폴더에서 가져옵니다.
 import { EnsembleForm, type RecruitEnsembleFormState } from '@/pages/ensemble/components/EnsembleForm';
 import axios from 'axios';
@@ -30,6 +31,7 @@ interface CreateRecruitEnsemblePayload {
 }
 
 const CreateRecruitEnsemblePage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const navigate = useNavigate();
   const { user } = useAuthStore();
 
@@ -159,7 +161,7 @@ const CreateRecruitEnsemblePage: React.FC = () => {
   }
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="bg-brand-frame p-4">
         <EnsembleForm
           formState={form}

--- a/WebFrontend/src/pages/ensemble/RecruitEnsembleDetailPage.tsx
+++ b/WebFrontend/src/pages/ensemble/RecruitEnsembleDetailPage.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { useChatStore } from '../../stores/chatStore';
 import axiosInstance from '@/services/axiosInstance';
 import axios from 'axios';
 import type { RecruitEnsemble, ApplicationEnsemble } from './types';
@@ -14,6 +15,7 @@ import RecruitEnsembleDetail from '@/components/layout/pages/ensemble/EnsembleDe
 
 
 const RecruitEnsembleDetailPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const { user } = useAuthStore();
   // URL 파라미터에서 게시글 ID를 가져옵니다.
   const { id } = useParams<{ id: string }>();
@@ -133,6 +135,7 @@ const RecruitEnsembleDetailPage: React.FC = () => {
 
   return (
     <RecruitEnsembleDetail
+      totalUnreadCount={totalUnreadCount}
       post={ensemble}
       isOwner={isOwner}
       onEdit={handleEdit}

--- a/WebFrontend/src/pages/ensemble/RecruitEnsemblePage.tsx
+++ b/WebFrontend/src/pages/ensemble/RecruitEnsemblePage.tsx
@@ -1,6 +1,7 @@
 // src/pages/RecruitEnsembleListPage.tsx
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useChatStore } from '../../stores/chatStore';
 import axiosInstance from '@/services/axiosInstance';
 import PostLayout from '@/components/layout/PostLayout';
 import SwiperTabs from '@/components/organisms/PostNavigationTabs';
@@ -28,6 +29,7 @@ interface PaginatedEnsembleResponse {
 }
 
 const RecruitEnsembleListPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const [items, setItems] = useState<RecruitEnsemble[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -104,7 +106,7 @@ const RecruitEnsembleListPage: React.FC = () => {
   }, []);
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="grid grid-cols-1 py-4">
         {/* --- 에러 메시지 --- */}
         {error && (

--- a/WebFrontend/src/pages/ensemble/types/index.ts
+++ b/WebFrontend/src/pages/ensemble/types/index.ts
@@ -48,6 +48,7 @@ export interface RecruitEnsemble {
   createdAt: string;
   viewCount: number;
   sessionEnsemble: SessionEnsemble[]
+  totalUnreadCount?: number;
 }
 
 export enum SKILL_LEVEL {

--- a/WebFrontend/src/pages/main/MainPage.tsx
+++ b/WebFrontend/src/pages/main/MainPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import { useUiStore } from "@/stores/uiStore";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useChatStore } from '../../stores/chatStore';
 
 // Dev 모드 상태 관리를 위한 store
 // const useDevModeStore = () => {
@@ -66,6 +67,7 @@ const CategoryCard: React.FC<{
 );
 
 const MainPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const navigate = useNavigate();
   const location = useLocation();
   const user = useAuthStore((state) => state.user);
@@ -130,6 +132,7 @@ const MainPage: React.FC = () => {
 
   return (
     <Layout
+      totalUnreadCount={totalUnreadCount}
       currentPath={location.pathname}
       onSearchClick={handleSearchClick}
       onCategoryClick={handleCategoryClick}

--- a/WebFrontend/src/pages/notification/NotificationsPage.tsx
+++ b/WebFrontend/src/pages/notification/NotificationsPage.tsx
@@ -3,6 +3,7 @@
 import React, {useEffect} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useNotifications } from '@/hooks/useNotifications';
+import { useChatStore } from '../../stores/chatStore';
 import PostLayout from '@/components/layout/PostLayout'; // 재사용 가능한 레이아웃
 import Icon from '@/components/atoms/icon/Icon';
 
@@ -22,6 +23,7 @@ const timeSince = (date: Date): string => {
   };
 
   const NotificationsPage: React.FC = () => {
+    const { totalUnreadCount } = useChatStore();
     const { notifications, unreadCount, markAsRead, markAllAsRead } = useNotifications();
     const navigate = useNavigate();
 
@@ -50,7 +52,7 @@ const timeSince = (date: Date): string => {
 
 
     return (
-        <PostLayout>
+        <PostLayout totalUnreadCount={totalUnreadCount}>
             <div className="p-4">
                 <div className="flex justify-between items-center mb-4">
                     <h1 className="text-headline font-bold">알림</h1>

--- a/WebFrontend/src/pages/practiceRoom/CreatePracticeRoomPage.tsx
+++ b/WebFrontend/src/pages/practiceRoom/CreatePracticeRoomPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useChatStore } from '../../stores/chatStore';
 import axiosInstance from "@/services/axiosInstance";
 import {
   type CreatePracticeRoomPayload,
@@ -12,6 +13,7 @@ import { PracticeRoomForm } from "@/components/layout/pages/practiceRoom/Practic
 import PostLayout from "@/components/layout/PostLayout";
 
 const CreatePracticeRoom: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const navigate = useNavigate();
   const { user } = useAuthStore();
   const [form, setForm] = useState<PracticeRoomType>({
@@ -99,7 +101,7 @@ const CreatePracticeRoom: React.FC = () => {
   };
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="bg-brand-frame p-4">
         <PracticeRoomForm
           formState={form}

--- a/WebFrontend/src/pages/practiceRoom/PracticeRoomDetailPage.tsx
+++ b/WebFrontend/src/pages/practiceRoom/PracticeRoomDetailPage.tsx
@@ -3,11 +3,12 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '@/services/axiosInstance';
 import { type PracticeRoom } from '@/types/practiceRoom';
 import { useAuthStore } from '@/stores/authStore';
+import { useChatStore } from '../../stores/chatStore';
 import { PracticeRoomDetail } from '@/components/layout/pages/practiceRoom/PracticeRoomDetailForm';
 import useViewCounter from '@/hooks/useViewCounter';
 
-const PracticeRoomDetailPage: React.FC = () => 
-{
+const PracticeRoomDetailPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { user } = useAuthStore();
@@ -76,6 +77,7 @@ const PracticeRoomDetailPage: React.FC = () =>
 
     return (
       <PracticeRoomDetail
+        totalUnreadCount={totalUnreadCount}
         post={post}
         isOwner={isOwner}
         onEdit={handleEdit}

--- a/WebFrontend/src/pages/practiceRoom/PracticeRoomPage.tsx
+++ b/WebFrontend/src/pages/practiceRoom/PracticeRoomPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useChatStore } from '../../stores/chatStore';
 import {
   type PracticeRoom,
   type PaginatedPracticeRoomResponse,
@@ -18,6 +19,7 @@ interface Cursor {
 }
 
 const PracticeRoomPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const [post, setItems] = useState<PracticeRoom[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,7 +93,7 @@ const PracticeRoomPage: React.FC = () => {
   };
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="relative">
         <ImageCard 
           src="https://placehold.co/390x314/F4EDFE/ffffff?text=.."

--- a/WebFrontend/src/pages/practiceRoom/UpdatePracticeRoomPage.tsx
+++ b/WebFrontend/src/pages/practiceRoom/UpdatePracticeRoomPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useChatStore } from '../../stores/chatStore';
 import axiosInstance from '@/services/axiosInstance';
 import { type PracticeRoomType, type CreatePracticeRoomPayload, type PracticeRoom } from '@/types/practiceRoom';
 import { useLocationStore } from '@/components/map/store/useLocationStore';
@@ -9,6 +10,7 @@ import { PracticeRoomForm } from '@/components/layout/pages/practiceRoom/Practic
 import PostLayout from '@/components/layout/PostLayout';
 
 const UpdatePracticeRoomPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const { user } = useAuthStore();
@@ -105,7 +107,7 @@ const UpdatePracticeRoomPage: React.FC = () => {
   if (error) return <div className="message-container error-message">{error}</div>;
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="bg-brand-frame p-4">
         <PracticeRoomForm
           formState={form}

--- a/WebFrontend/src/pages/usedProduct/CreateUsedProductPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/CreateUsedProductPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useChatStore } from '../../stores/chatStore';
 import axios from 'axios';
 import { TRADE_TYPE, type UsedProductForm, type CreateUsedProductPayload } from '../../types/product';
 import { ProductForm } from '../../components/layout/pages/usedProduct/ProductForm';
@@ -10,6 +11,7 @@ import { saveLocationToDB } from '@/components/map/LocationSaveHandler';
 import PostLayout from '@/components/layout/PostLayout';
 
 const CreateUsedProductPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const navigate = useNavigate();
   const { user } = useAuthStore(); // 스토어에서 user 정보 가져오기
   const [form, setForm] = useState<UsedProductForm>({
@@ -122,7 +124,7 @@ const CreateUsedProductPage: React.FC = () => {
   }
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="bg-brand-frame p-4">
         <ProductForm
           formState={form}

--- a/WebFrontend/src/pages/usedProduct/UpdateUsedProductPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UpdateUsedProductPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useChatStore } from '../../stores/chatStore';
 import axios from 'axios';
 import { TRADE_TYPE, type UsedProductForm, type UsedProduct } from '../../types/product';
 import { ProductForm } from '../../components/layout/pages/usedProduct/ProductForm'; // 재사용 폼 컴포넌트 import
@@ -12,6 +13,7 @@ import { saveLocationToDB } from '@/components/map/LocationSaveHandler';
 import PostLayout from '@/components/layout/PostLayout';
 
 const UpdateUsedProductPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const location = useLocationStore((state) => state.location);
@@ -122,7 +124,7 @@ const UpdateUsedProductPage: React.FC = () => {
   };
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div className="bg-brand-frame p-4">
         <ProductForm
           formState={form}

--- a/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useChatStore } from '../../stores/chatStore';
 import axios from 'axios';
 import { type UsedProduct, TRADE_TYPE, STATUS, STATUS_TEXT } from '../../types/product';
 import { useAuthStore } from '@/stores/authStore';
@@ -25,6 +26,7 @@ const TRADE_TYPE_TEXT = {
 };
 
 const UsedProductDetailPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const { user } = useAuthStore();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -150,7 +152,7 @@ const UsedProductDetailPage: React.FC = () => {
   if (!product) return renderStatusMessage('상품 정보가 없습니다.', true);
 
   return (
-    <PostLayout bgClassName="bg-white">
+    <PostLayout totalUnreadCount={totalUnreadCount} bgClassName="bg-white">
       <div className="mx-auto max-w-6xl px-4 mb-8">
         <div className="flex flex-col">
           {/* 이미지 섹션 */}

--- a/WebFrontend/src/pages/usedProduct/UsedProductPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useChatStore } from '../../stores/chatStore';
 import { type UsedProduct, type PaginatedUsedProductResponse, CATEGORY_LABEL_TO_ID } from '../../types/product';
 import axiosInstance from '@/services/axiosInstance';
 import CategoryList from '@/components/layout/CategoryList';
@@ -13,6 +14,7 @@ interface Cursor {
 }
 
 const UsedProductPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const [items, setItems] = useState<UsedProduct[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -80,7 +82,7 @@ const UsedProductPage: React.FC = () => {
   };
 
   return (
-    <PostLayout>
+    <PostLayout totalUnreadCount={totalUnreadCount}>
       <div>
         <div className="relative w-full max-w-[410px] mx-auto min-h-screen bg-brand-frame">
           <div className="py-4 px-4">

--- a/WebFrontend/src/pages/user/UserPage.tsx
+++ b/WebFrontend/src/pages/user/UserPage.tsx
@@ -1,6 +1,7 @@
 // src/pages/user/UserPage.tsx
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { useChatStore } from '../../stores/chatStore';
 import axiosInstance from "../../services/axiosInstance";
 import ProfileContentTabs from "@/components/organisms/ProfileContentTabs";
 import SearchOverlay from "@/components/organisms/SearchOverlay";
@@ -28,6 +29,7 @@ interface UserProfile {
 }
 
 const UserPage: React.FC = () => {
+  const { totalUnreadCount } = useChatStore();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [isSearchOverlayOpen, setIsSearchOverlayOpen] = useState(false);
@@ -240,6 +242,7 @@ const UserPage: React.FC = () => {
 
   return (
     <MyPageLayout
+      totalUnreadCount={totalUnreadCount}
       onSettingsClick={() => setIsSettingsModalOpen(true)}
       onSearchClick={() => setIsSearchOverlayOpen(true)}
     >

--- a/WebFrontend/src/stores/chatStore.ts
+++ b/WebFrontend/src/stores/chatStore.ts
@@ -1,46 +1,44 @@
-// src/stores/chatStore.ts
 import { create } from 'zustand';
-import axiosInstance from '../services/axiosInstance'; // axios 인스턴스 경로
-import { socket } from '../services/socket';           // socket 인스턴스 경로
-import { useAuthStore } from './authStore';           // 인증 스토어 경로
+import axiosInstance from '../services/axiosInstance';
+import { socket } from '../services/socket';
+import { useAuthStore } from './authStore';
+import { type Socket } from 'socket.io-client';
 
 // --- 타입 정의 ---
 export interface Message {
   id: string;
   roomId: string;
-  senderId?: string; // 시스템 메시지는 senderId가 없을 수 있음
+  senderId?: string;
   content: string;
   createdAt: string;
   sender?: {
-    id: string;
+    id:string;
     username: string;
     profileUrl: string | null;
   };
-  isSystem?: boolean; // 시스템 메시지 여부를 나타내는 플래그
+  isSystem?: boolean;
 }
 
-// 채팅 상대방 정보 타입
+interface MyRoom { id: string; }
+
 interface ChatPartner {
   id: string | null;
   username: string;
   profileUrl: string | null;
 }
 
-// 스토어의 상태와 액션을 정의하는 타입
 interface ChatState {
-  // --- 상태 (State) ---
-  isConnected: boolean; // ⬅️ 소켓 연결 상태 추가
+  socket: Socket;
+  isConnected: boolean;
   roomId: string | null;
   messages: Message[];
   chatPartner: ChatPartner;
   isModalOpen: boolean;
   modalType: 'invite' | 'leave' | null;
-  
   page: number;
-  hasMore: boolean; // 더 불러올 메시지가 있는지 여부
-  isLoadingMore: boolean; // 추가 메시지 로딩 중 상태
-
-  // --- 액션 (Actions) ---
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  totalUnreadCount: number;
   initializeRoom: (roomId: string) => Promise<void>;
   loadMoreMessages: () => Promise<void>;
   sendMessage: (content: string) => void;
@@ -50,52 +48,71 @@ interface ChatState {
   closeModal: () => void;
   cleanupRoom: () => void;
   initializeSocketListeners: () => void;
-  disconnectSocket: () => void; // ⬅️ 추가
-
+  disconnectSocket: () => void;
+  fetchTotalUnreadCount: () => Promise<void>;
 }
 
 let isSocketInitialized = false;
 
 export const useChatStore = create<ChatState>((set, get) => ({
-  // --- 초기 상태 값 (변경 없음) ---
+  socket: socket,
   isConnected: false,
   roomId: null,
   messages: [],
   chatPartner: { id: null, username: '대화 상대 로딩...', profileUrl: null },
   isModalOpen: false,
   modalType: null,
-
   page: 1,
   hasMore: true,
   isLoadingMore: false,
-  /**
-   * 소켓 이벤트 리스너를 초기화하는 액션 (앱 실행 시 한 번만 호출)
-   */
-   initializeSocketListeners: () => {
-    // 이미 초기화되었다면 절대 다시 실행하지 않음
-    if (isSocketInitialized) {
-      return;
+  totalUnreadCount: 0,
+  
+  fetchTotalUnreadCount: async () => {
+    try {
+      const response = await axiosInstance.get<{ unreadCount: number }>('chat/unread-count');
+      set({ totalUnreadCount: response.data.unreadCount });
+    } catch (error) {
+      console.error("Failed to fetch total unread count", error);
+      set({ totalUnreadCount: 0 });
     }
+  },
 
-    // --- 모든 이벤트 리스너를 최상위 레벨에서 한 번만 등록 ---
-
-    socket.on('connect', () => {
+  initializeSocketListeners: () => {
+    if (isSocketInitialized) return;
+    const currentSocket = get().socket;
+    currentSocket.on('connect', async () => {
       console.log('✅ 소켓 연결 성공!');
       set({ isConnected: true });
+      const { user } = useAuthStore.getState();
+      if (user) {
+        try {
+          const response = await axiosInstance.get<MyRoom[]>('chat/my-rooms');
+          const myRooms = response.data;
+          if (myRooms && myRooms.length > 0) {
+            console.log('Joining all my rooms:', myRooms.map(r => r.id));
+            myRooms.forEach(room => {
+              currentSocket.emit('joinRoom', { id: user.id, roomId: room.id });
+            });
+          }
+        } catch (error) {
+          console.error("Failed to fetch and join my rooms on connect", error);
+        }
+      }
     });
-
-    socket.on('disconnect', () => {
+    currentSocket.on('disconnect', () => {
       console.log('❌ 소켓 연결이 끊어졌습니다.');
       set({ isConnected: false });
     });
-
-    socket.on('newMessage', (message: Message) => {
+    currentSocket.on('newMessage', (message: Message) => {
       if (get().roomId === message.roomId) {
         set((state) => ({ messages: [...state.messages, message] }));
       }
     });
-
-    socket.on('userLeft', (data: { username: string; roomId: string }) => {
+    currentSocket.on('unreadCountUpdated', () => {
+      console.log('🔄 안 읽은 메시지 수 업데이트 신호 수신!');
+      get().fetchTotalUnreadCount();
+    });
+    currentSocket.on('userLeft', (data: { username: string; roomId: string }) => {
       if (get().roomId === data.roomId) {
         const systemMessage: Message = {
           id: `system-${Date.now()}`,
@@ -107,8 +124,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         set((state) => ({ messages: [...state.messages, systemMessage] }));
       }
     });
-
-    socket.on('userInvited', (data: { username: string; roomId: string }) => {
+    currentSocket.on('userInvited', (data: { username: string; roomId: string }) => {
       if (get().roomId === data.roomId) {
         const systemMessage: Message = {
           id: `system-${Date.now()}`,
@@ -120,22 +136,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
         set((state) => ({ messages: [...state.messages, systemMessage] }));
       }
     });
-
-    // --- 리스너 등록 후 연결 시도 ---
-    socket.connect();
-    
-    // 초기화 완료 플래그를 true로 설정하여 다시는 이 함수가 실행되지 않도록 함
+    currentSocket.connect();
     isSocketInitialized = true;
   },
   
   disconnectSocket: () => {
-    if (socket?.connected) {
-      socket.disconnect();
+    if (get().socket?.connected) {
+      get().socket.disconnect();
     }
-    // isSocketInitialized는 false로 바꾸지 않습니다. 리스너는 계속 유지되어야 합니다.
   },
 
-  // ... (initializeRoom, sendMessage 등 다른 액션들은 변경 없음) ...
   initializeRoom: async (roomId) => {
     const { user: currentUser } = useAuthStore.getState();
     if (!currentUser) return;
@@ -160,77 +170,70 @@ export const useChatStore = create<ChatState>((set, get) => ({
       )?.sender;
       if (partner) {
         set({
-          chatPartner: {
-            id: partner.id,
-            username: partner.username,
-            profileUrl: partner.profileUrl,
-          },
+          chatPartner: { id: partner.id, username: partner.username, profileUrl: partner.profileUrl },
         });
       } else {
+        const roomDetailsResponse = await axiosInstance.get(`chat/rooms/${roomId}`);
+        const otherUser = roomDetailsResponse.data.userRooms.find(ur => ur.user.id !== currentUser.id)?.user;
         set({
-          chatPartner: { id: null, username: '새로운 대화', profileUrl: null },
+          chatPartner: otherUser 
+            ? { id: otherUser.id, username: otherUser.username, profileUrl: otherUser.profileUrl }
+            : { id: null, username: '새로운 대화', profileUrl: null },
         });
       }
     } catch (error) {
       console.error('메시지 기록 로딩 실패:', error);
-      set({
-        chatPartner: { id: null, username: '정보 없음', profileUrl: null },
-      });
+      set({ chatPartner: { id: null, username: '정보 없음', profileUrl: null }});
     }
-    socket.emit('joinRoom', { id: currentUser.id, roomId });
+    get().socket.emit('joinRoom', { id: currentUser.id, roomId });
   },
+
   sendMessage: (content) => {
     const { roomId } = get();
     const { user } = useAuthStore.getState();
     if (!content.trim() || !roomId || !user) return;
-    socket.emit('sendMessage', {
+    get().socket.emit('sendMessage', {
       roomId,
       senderId: user.id,
-      senderName: user.username,
       content,
     });
   },
+  
   inviteUser: (inviteeId) => {
     const { roomId } = get();
     if (!inviteeId.trim() || !roomId) return;
-    socket.emit('inviteUser', { roomId, inviteeId });
+    get().socket.emit('inviteUser', { roomId, inviteeId });
     get().closeModal();
   },
+
   loadMoreMessages: async () => {
     const { roomId, page, hasMore, isLoadingMore, messages } = get();
-    const { user: currentUser } = useAuthStore.getState();
-
-    if (!roomId || !currentUser || !hasMore || isLoadingMore) {
-      return;
-    }
-
+    if (!roomId || !hasMore || isLoadingMore) return;
     set({ isLoadingMore: true });
-
     try {
       const response = await axiosInstance.get(`chat/rooms/${roomId}/history?page=${page}&limit=20`);
       const olderMessages: Message[] = response.data.reverse();
-
       set({
-        // 새로 불러온 메시지(과거)를 기존 메시지(현재) 앞에 추가
         messages: [...olderMessages, ...messages],
         page: page + 1,
         hasMore: olderMessages.length === 20,
       });
-
     } catch (error) {
       console.error('이전 메시지 로딩 실패:', error);
     } finally {
       set({ isLoadingMore: false });
     }
   },
+  
   leaveCurrentRoom: () => {
     const { roomId } = get();
     const { user } = useAuthStore.getState();
     if (!roomId || !user) return;
-    socket.emit('leaveRoom', { id: user.id, roomId });
+    get().socket.emit('leaveRoom', { id: user.id, roomId });
     get().cleanupRoom();
     get().closeModal();
   },
+
   openModal: (type) => set({ isModalOpen: true, modalType: type }),
   closeModal: () => set({ isModalOpen: false, modalType: null }),
   cleanupRoom: () => {


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [ ] 읽지 않은 메시지에 대한 알림 기능과 실시간 업데이트 로직 구현
- [ ] Backend
- [ ] [DB] 메시지 읽음 상태를 사용자별로 추적하기 위해 UserMessageRead 엔티티를 추가
- [ ] [API] 로그인한 유저의 전체 안 읽은 메시지 수를 반환하는 API를 구현 (GET /api/chat/unread-count)
- [ ] [API] 특정 채팅방의 모든 메시지를 읽음 처리하는 API를 구현 (POST /api/chat/rooms/:id/read)
- [ ] [API] 유저가 속한 채팅방 목록을 반환할 때, 각 방의 안 읽은 메시지 수(unreadCount)를 포함하도록 수정 (GET /api/chat/my-rooms)
- [ ] [WebSocket] 새 메시지 전송 시, 해당 채팅방에 있는 클라이언트들에게 안 읽은 메시지 수를 갱신하라는 unreadCountUpdated 이벤트를 전송하는 로직을 추가
- [ ] [Fix] 모듈 간 순환 의존성 문제를 해결하기 위해 forwardRef를 적용하고, UserService의 exports 설정을 확인
- [ ] Frontend
- [ ] [State] zustand 스토어(chatStore)에 전역 totalUnreadCount 상태와 관련 액션(fetchTotalUnreadCount)을 추가
- [ ] [WebSocket] 백엔드에서 오는 unreadCountUpdated 이벤트를 수신하여 fetchTotalUnreadCount를 호출, 안 읽은 메시지 수를 실시간으로 갱신하는 리스너를 추가
- [ ] [WebSocket] 앱 시작 및 로그인 시, 사용자가 속한 모든 채팅방에 자동으로 join 하도록 로직을 개선하여 어느 페이지에서든 실시간 알림을 받을 수 있도록 수정
- [ ] [UI] MainFooter 컴포넌트의 채팅 아이콘에 안 읽은 메시지 총 개수를 나타내는 배지를 구현
- [ ] [UI] ChatListPage에서 각 채팅방 별로 안 읽은 메시지 수를 배지로 표시하고, 안 읽은 방은 시각적으로 구분되도록 스타일을 추가
- [ ] [Logic] ChatRoomPage 진입 시, 해당 방의 메시지를 모두 읽음 처리하고 전역 안 읽은 메시지 수를 갱신하는 API를 호출하도록 로직을 구현


## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 사용자 A, 사용자 B로 각각 다른 브라우저에서 로그인
2. 사용자 A가 메인 페이지나 다른 페이지에 있는 상태에서, 사용자 B가 A에게 메시지를 보낸다
3. [확인] 사용자 A의 화면 하단 푸터에 있는 채팅 아이콘에 새로고침 없이 실시간으로 숫자 배지가 나타나는지 확인
4. 사용자 A가 채팅 목록 페이지(/chat)로 이동
5. [확인] 사용자 B와의 채팅방 목록에 안 읽은 메시지 수 배지가 정상적으로 표시되는지 확인
6. 사용자 A가 사용자 B와의 채팅방에 들어갑니다.
7. [확인] 채팅방에 들어가는 즉시 하단 푸터의 배지와 채팅방 목록의 배지(채팅 목록으로 다시 돌아갔을 때)가 사라지는지 확인
8. 여러가지 페이지를 이동하면서 푸터에 알림이 실시간으로 오는지 확인


## 🖼️ 스크린샷 (선택 사항)
<img width="446" height="766" alt="스크린샷 2025-07-20 오전 8 15 39" src="https://github.com/user-attachments/assets/4d9f70c8-a961-4d2d-8b8f-e6775c0353c1" />

## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.