### PR TITLE
refactor: 합주실 예약 db에서 user정보를 참조하도록 변경

### DIFF
--- a/BackendServer/src/practice_room/dto/create-practice-room.dto.ts
+++ b/BackendServer/src/practice_room/dto/create-practice-room.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsString, IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty, IsNumber, IsOptional, IsArray, IsInt } from 'class-validator';
 
 export class CreatePracticeRoomDto {
   @IsString()
@@ -10,13 +10,11 @@ export class CreatePracticeRoomDto {
   @IsNotEmpty()
   description: string;
 
-  @IsString()
-  @IsOptional()
-  user_name: string;
-
-  @IsString()
-  @IsOptional()
-  iamges?: string;
+  @IsOptional() // 이미지는 선택 사항일 수 있으므로 Optional 처리
+  @IsArray()
+  @Type(() => Number)
+  @IsInt({ each: true })
+  imageIds?: number[];
 
   @Type(() => Number)
   @IsNumber()

--- a/BackendServer/src/practice_room/entities/practice-room.entity.ts
+++ b/BackendServer/src/practice_room/entities/practice-room.entity.ts
@@ -8,14 +8,18 @@ import {
 } from 'typeorm';
 
 import { Location } from 'src/map/entities/location.entity';
+import { User } from 'src/auth/user/user.entity';
 
 @Entity({ name: 'practice_rooms' })
 export class PracticeRoom {
   @PrimaryGeneratedColumn()
   postId: number;
 
-  @Column()
-  id: string;
+  @ManyToOne(() => User, (user: User) => user.userRooms, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'user' })
+  user: User;
 
   @Column()
   title: string;

--- a/BackendServer/src/practice_room/practice-room.controller.ts
+++ b/BackendServer/src/practice_room/practice-room.controller.ts
@@ -62,29 +62,52 @@ export class PracticeRoomController {
     );
   }
 
-  @Get(':id')
+  @Get(':postId')
   async detailPracticeRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('postId', ParseIntPipe) postId: number,
   ): Promise<PracticeRoom> {
-    this.logger.log(`Fetching detail for post ID: ${id}`);
-    return await this.practiceRoomService.detailPracticeRoom(id);
+    this.logger.log(`Fetching detail for post ID: ${postId}`);
+    return await this.practiceRoomService.detailPracticeRoom(postId);
   }
 
-  @Delete(':id')
+  @Delete(':postId')
+  @UseGuards(AuthGuard('jwt'))
   @HttpCode(204)
   async deletePracticeRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('postId', ParseIntPipe) postId: number,
+    @Req() req: Request,
   ): Promise<void> {
-    this.logger.log(`Delete Post ID: ${id}`);
-    await this.practiceRoomService.deletePracticeRoom(id);
+    if (!req.user || !req.user.id) {
+      this.logger.error(
+        'Authentication information missing from request user object.',
+      );
+      throw new ForbiddenException('사용자 인증 정보가 없습니다.');
+    }
+    const id = req.user.id;
+    this.logger.log(
+      `Received delete request for product ID: ${postId} from user ID: ${id}`,
+    );
+    await this.practiceRoomService.deletePracticeRoom(postId, id);
   }
 
-  @Patch(':id')
+  @Patch(':postId')
+  @UseGuards(AuthGuard('jwt'))
   async pathPracticeRoom(
-    @Param('id', ParseIntPipe) id: number,
+    @Param('postId', ParseIntPipe) postId: number,
     @Body() UpdatePracticeRoomDto: UpdatePracticeRoomDto,
+    @Req() req: Request,
   ): Promise<PracticeRoom> {
-    this.logger.log(`Patching Post Id: ${id}`);
-    return this.practiceRoomService.pathPracticeRoom(id, UpdatePracticeRoomDto);
+    if (!req.user || !req.user.id) {
+      this.logger.error(
+        'Authentication information missing from request user object.',
+      );
+      throw new ForbiddenException('사용자 인증 정보가 없습니다.');
+    }
+    const id = req.user.id; // JwtStrategy에서 반환된 user.id 사용 가능
+    this.logger.log(
+      `Received patch request for product ID: ${postId} from user ID: ${id}`,
+    );
+
+    return this.practiceRoomService.pathPracticeRoom(postId, UpdatePracticeRoomDto, id);
   }
 }

--- a/BackendServer/src/practice_room/practice-room.module.ts
+++ b/BackendServer/src/practice_room/practice-room.module.ts
@@ -4,11 +4,13 @@ import { PracticeRoomService } from './practice-room.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PracticeRoom } from './entities/practice-room.entity';
 import { LocationModule } from 'src/map/location.module';
+import { UserModule } from 'src/auth/user/user.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([PracticeRoom]),
     forwardRef(() => LocationModule),
+    UserModule,
   ],
   controllers: [PracticeRoomController],
   providers: [PracticeRoomService],

--- a/BackendServer/src/practice_room/practice-room.service.ts
+++ b/BackendServer/src/practice_room/practice-room.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PracticeRoom } from './entities/practice-room.entity';
@@ -6,12 +6,15 @@ import { CreatePracticeRoomDto } from './dto/create-practice-room.dto';
 import { UpdatePracticeRoomDto } from './dto/update-practice-room.dto';
 import { PaginatedPracticeRoomResponse } from './dto/paginated-practice-room.response.dto';
 import { Location } from 'src/map/entities/location.entity';
+import { UserService } from 'src/auth/user/user.service';
+
 
 @Injectable()
 export class PracticeRoomService {
   constructor(
     @InjectRepository(PracticeRoom)
     private readonly practiceRoomRepo: Repository<PracticeRoom>,
+    private readonly userService: UserService,
 
     @InjectRepository(Location)
     private readonly locationRepo: Repository<Location>,
@@ -75,10 +78,16 @@ export class PracticeRoomService {
       throw new NotFoundException(`Location with ID #${locationId} not found.`);
     }
 
+    const user = await this.userService.findById(id);
+    if (!user) {
+      throw new NotFoundException(`User with ID "${id}" not found`);
+    }
+    
+
     const newPracticeRoom = this.practiceRoomRepo.create({
       ...restofDto,
       locationId: locationEntity.locationId,
-      id: id, // 실제 유저 ID를 사용해야 합니다
+      user: user, // 실제 유저 ID를 사용해야 합니다
       viewCount: 0,
     });
     return await this.practiceRoomRepo.save(newPracticeRoom);
@@ -87,7 +96,7 @@ export class PracticeRoomService {
   async detailPracticeRoom(id: number): Promise<PracticeRoom> {
     const post = await this.practiceRoomRepo.findOne({
       where: { postId: id },
-      relations: ['location'], // ← location 조인!
+      relations: ['location', 'user'], // ← location 조인!
     });
     if (!post) {
       throw new NotFoundException(`Post withID #${id} not found`);
@@ -95,23 +104,32 @@ export class PracticeRoomService {
     return post;
   }
 
-  async deletePracticeRoom(id: number): Promise<void> {
-    const post = await this.practiceRoomRepo.delete({ postId: id });
-    if (post.affected === 0) {
+  async deletePracticeRoom(postId: number, id: string): Promise<void> {
+    const post = await this.detailPracticeRoom(postId);
+    if(id !== post?.user.id){
+      throw new ForbiddenException(`Unauthorized`);
+    }
+    const result = await this.practiceRoomRepo.delete({ postId: postId });
+    if (result.affected === 0) {
       throw new NotFoundException(`Post withID #${id} not found`);
     }
   }
 
   async pathPracticeRoom(
-    id: number,
+    postId: number,
     updateDto: UpdatePracticeRoomDto,
+    id: string,
   ): Promise<PracticeRoom> {
-    const post = await this.detailPracticeRoom(id);
+    const post = await this.detailPracticeRoom(postId);
+    if (id !== post.user.id) {
+      throw new ForbiddenException(`Unauthorized`);
+    }
+
     const updatedPost = this.practiceRoomRepo.merge(post, updateDto);
     return this.practiceRoomRepo.save(updatedPost);
   }
 
-  async incrementViewCount(id: number): Promise<void> {
-    await this.practiceRoomRepo.increment({ postId: id }, 'viewCount', 1);
+  async incrementViewCount(postId: number): Promise<void> {
+    await this.practiceRoomRepo.increment({ postId: postId }, 'viewCount', 1);
   }
 }

--- a/WebFrontend/src/components/layout/pages/practiceRoom/PracticeRoomDetailForm.tsx
+++ b/WebFrontend/src/components/layout/pages/practiceRoom/PracticeRoomDetailForm.tsx
@@ -58,7 +58,7 @@ export const PracticeRoomDetail: React.FC<PracticeRoomDetailProps> = ({
         <div className="flex flex-col w-full mx-auto px-4 gap-4">
           <UserProfileCard
             imageUrl={post.imageUrl || 'https://placehold.co/40x40'}
-            name={post.id}
+            name={post.user.username}
             location={post.location.address}
             statusSlot={<button className={`${baseStatusStyle} ${styles.bg} ${styles.text} ${styles.hover}`}>예약하기</button>}
           />

--- a/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
+++ b/WebFrontend/src/pages/usedProduct/UsedProductDetailPage.tsx
@@ -119,7 +119,7 @@ const UsedProductDetailPage: React.FC = () => {
     try {
       // 백엔드의 POST /chat/dm API를 호출합니다.
       const response = await axiosInstance.post("/chat/dm", {
-        partnerId: product.id, // 판매자의 ID를 전송
+        partnerId: product.user.id, // 판매자의 ID를 전송
       });
 
       const room = response.data;

--- a/WebFrontend/src/types/practiceRoom.ts
+++ b/WebFrontend/src/types/practiceRoom.ts
@@ -1,3 +1,5 @@
+import type { User } from '@/stores/authStore';
+
 export interface Location {
   locationId: string;
   regionLevel1: string;
@@ -11,8 +13,7 @@ export interface Location {
 // -- DB에 저장된 상품 데이터의 완전한 형태 -- 
 export interface PracticeRoom {
   readonly postId: number;
-  readonly id: string;
-  user_name: string;
+  user: User;
   title: string;
   description: string;
   readonly createdAt: string;


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [x] 합주실 예약 페이지에서 user db 테이블을 직접 참조하도록 변경합니다 
- [x] 상세 페이지에서 username을 반환하도록 변경합니다. 전체 게시판과 구조 통일화 
- [x] 중고거래 페이지에서 dm 연결 버그 픽스 


## 🔗 관련 이슈
Closes #249 


## ✓ 테스트 방법
1. 
2. 
3. 


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.