### PR TITLE
fix: 중고거래 이미지 presignedUrl 방식으로 로딩 변경

### DIFF
--- a/BackendServer/src/used_product/used-product.service.ts
+++ b/BackendServer/src/used_product/used-product.service.ts
@@ -78,18 +78,22 @@ export class UsedProductService {
     // 참조하는 이미지가 없는 경우를 아래 쿼리를 실행하지 않음
     if (productIds.length === 0) return { data: [], nextCursor, hasNextPage };
 
+    // 각 상품에 연결된 썸네일 이미지만 조회 (썸네일 플래그 + 경로 기반으로 이중 필터링)
     const thumbnails = await this.imageRepo
       .createQueryBuilder('image')
       .where('image.refPostId IN (:...productIds)', { productIds })
       .andWhere('image.isThumbnail = true')
+      .andWhere("image.imageKey LIKE :pattern", { pattern: '%/thumbnail/%' })
       .getMany();
 
+    // 썸네일 이미지에 대해 presigned URL을 발급하고, productId 기준으로 매핑
     const imageMap = new Map<number, string>();
-    thumbnails.forEach((img) => {
-      if (img.refPostId !== null && !imageMap.has(img.refPostId)) {
-        imageMap.set(Number(img.refPostId), img.imageKey);
+    for (const img of thumbnails) {
+      if (img.refPostId !== null && !imageMap.has(Number(img.refPostId))) {
+        const signedUrl = await this.imageService.getDownloadUrl(img.imageKey); // presigned URL 생성
+        imageMap.set(Number(img.refPostId), signedUrl); // 상품 ID → 썸네일 URL 매핑
       }
-    });
+    }
 
     const dataWithThumbnails = data.map((product) => ({
       ...product,
@@ -180,9 +184,16 @@ export class UsedProductService {
     if (!product) {
       throw new NotFoundException(`Product with ID #${productId} not found.`);
     }
+    // 모든 이미지 조회 (원본 + 썸네일 포함)
     const images = await this.imageService.findImageByRefPostId(productId);
-    const imageIds = images.map((img) => img.imageId);
-    const imageUrl = images.map((img) => img.imageKey);
+    // 상세 페이지에서는 썸네일이 아닌 '원본 이미지'만 사용하므로 필터링
+    const originalImages = images.filter((img) => !img.imageKey.includes('/thumbnail/'));
+    const imageIds = originalImages.map((img) => img.imageId);
+
+    // 원본 이미지에 대해 S3 presigned URL을 발급하여 클라이언트가 접근 가능하도록 처리
+    const imageSignedUrls = await Promise.all(
+      originalImages.map((img) => this.imageService.getDownloadUrl(img.imageKey))
+    );
 
     let userProfileSignedUrl: string | null = null;
     if (product.user && product.user.profileUrl) {
@@ -204,7 +215,7 @@ export class UsedProductService {
     return {
       ...productDto,
       imageIds,
-      imageUrl,
+      imageUrl: imageSignedUrls,
     };
   }
 

--- a/WebFrontend/src/hooks/getImageUrl.ts
+++ b/WebFrontend/src/hooks/getImageUrl.ts
@@ -1,0 +1,7 @@
+export const getImageUrl = (keys: string[] | string | undefined): string[] => {
+  if (!keys) return [];
+  if (typeof keys === 'string') return [`https://recho-img.s3.ap-northeast-2.amazonaws.com/${keys}`];
+  return keys.map(k => `https://recho-img.s3.ap-northeast-2.amazonaws.com/${k}`);
+};
+
+export default getImageUrl;

--- a/WebFrontend/src/hooks/useImageUpload.ts
+++ b/WebFrontend/src/hooks/useImageUpload.ts
@@ -78,6 +78,7 @@ export const useImageUpload = () => {
     const payload = {
       images: Object.values(uploadData).map((data, idx) => ({
         key: data.key,
+        // key: `https://recho-img.s3.ap-northeast-2.amazonaws.com/${data.key}`,
         refIn,
         uploadOrder: idx,
         refPostId,

--- a/WebFrontend/src/pages/user/UserPage.tsx
+++ b/WebFrontend/src/pages/user/UserPage.tsx
@@ -20,7 +20,7 @@ import axios, { AxiosError } from "axios"; // AxiosError 타입 import
 import type { Video } from '@/types/video';
 import type { PaginatedUsedProductResponse } from '@/types/product';
 import type { Post } from '@/types/post';
-
+import Icon from "@/components/atoms/icon/Icon";
 
 // 타입 정의
 interface UserProfile {
@@ -278,12 +278,18 @@ const UserPage: React.FC = () => {
             <div className="relative w-full rounded-card bg-brand-default p-6 pt-12 text-center">
               <div className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2">
                 {isMyProfile && isEditing ? (
-                  <label htmlFor="profile-upload-input">
+                  <label htmlFor="profile-upload-input" className="relative block w-fit">
                     <Avatar
                       src={newProfileImageFile ? URL.createObjectURL(newProfileImageFile) : user.profileImageUrl || DEFAULT_IMAGES.PROFILE}
                       alt={`${user.username}의 프로필 사진`}
                       size={64}
                     />
+                    <div className="absolute bottom-0 right-0 bg-white rounded-full p-[2px]">
+                      <Icon 
+                        name="plus" 
+                        className="w-5 h-5 bg-brand-primary text-white font-bold rounded-full"
+                      />
+                    </div>
                     <input
                       id="profile-upload-input"
                       type="file"


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [x] 중고거래 페이지의 이미지 로딩 방식을 presigned URL로 접근하도록 변경합니다 
- [x] 프론트의 링크 에러를 해결합니다 
- [ ] 


## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 
2. 
3. 


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.