### PR TITLE
fix: 이미지 렌더링 로직 개선

### DIFF
--- a/BackendServer/src/used_product/used-product.service.ts
+++ b/BackendServer/src/used_product/used-product.service.ts
@@ -364,14 +364,16 @@ export class UsedProductService {
       .createQueryBuilder('image')
       .where('image.refPostId IN (:...productIds)', { productIds })
       .andWhere('image.isThumbnail = true')
+      .andWhere("image.imageKey LIKE :pattern", { pattern: '%/thumbnail/%' })
       .getMany();
 
     const imageMap = new Map<number, string>();
-    thumbnails.forEach((img) => {
-      if (img.refPostId !== null && !imageMap.has(img.refPostId)) {
-        imageMap.set(Number(img.refPostId), img.imageKey);
+    for (const img of thumbnails) {
+      if (img.refPostId !== null && !imageMap.has(Number(img.refPostId))) {
+        const signedUrl = await this.imageService.getDownloadUrl(img.imageKey); // presigned URL 생성
+        imageMap.set(Number(img.refPostId), signedUrl); // 상품 ID → 썸네일 URL 매핑
       }
-    });
+    }
 
     const dataWithThumbnails = data.map((product) => ({
       ...product,

--- a/WebFrontend/src/hooks/useImageUpload.ts
+++ b/WebFrontend/src/hooks/useImageUpload.ts
@@ -24,20 +24,41 @@ export const useImageUpload = () => {
 
   const resizeImage = async (file: File): Promise<File> => {
     const imageBitmap = await createImageBitmap(file);
+
+    const MAX_SIZE_KB = 90;
+    const TARGET_WIDTH = 400;
+    // 원본이 이미 작을 경우: 리사이즈 하지 않고 그대로 반환
+    if (imageBitmap.width <= TARGET_WIDTH && imageBitmap.height <= TARGET_WIDTH) {
+      return file;
+    }
+    
+    // 비율 유지하며 TARGET_WIDTH 이하로 리사이징할 비율 계산 (화질 개선을 위해 정수값의 픽셀 전달)
+    const scale = Math.min(TARGET_WIDTH / imageBitmap.width, TARGET_WIDTH / imageBitmap.height);
+    const targetWidth = Math.round(imageBitmap.width * scale);
+    const targetHeight = Math.round(imageBitmap.height * scale);
+
+    // 캔버스를 통해 이미지 리사이징
     const canvas = document.createElement('canvas');
-    const scale = 0.2; // 20% 크기로 축소
-    canvas.width = imageBitmap.width * scale;
-    canvas.height = imageBitmap.height * scale;
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
 
     const ctx = canvas.getContext('2d')!;
+    ctx.imageSmoothingEnabled = true;       // 안티앨리어싱 활성화
+    ctx.imageSmoothingQuality = 'high';     // 고화질 리사이징 설정
+
     ctx.drawImage(imageBitmap, 0, 0, canvas.width, canvas.height);
 
     return new Promise((resolve) => {
       canvas.toBlob((blob) => {
         if (blob) {
+          const sizeKB = blob.size / 1024;
+          if (sizeKB > MAX_SIZE_KB) {
+            // 용량 제한을 초과한 경우 로그 출력 (필요시 여기서 재압축 로직 가능)
+            console.warn(`썸네일이 ${sizeKB.toFixed(1)}KB로 ${MAX_SIZE_KB}KB를 초과함`);
+          }
           resolve(new File([blob], `thumb-${file.name}`, { type: 'image/jpeg' }));
         }
-      }, 'image/jpeg', 0.8);
+      }, 'image/jpeg', 0.95);
     });
   }
 


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용
- [x] 마이페이지에서 이미지를 가져올때 presignedUrl 방식으로 요청하도록 변경합니다 
- [x] 썸네일 생성 로직 개선
  - 기존 : 업로드된 모든 이미지를 무조건 0.2 스케일로 압축
  - 변경 : 최대 용량(KB), 최대 너비(px) 기준 설정. 기준 초과 시에만 리사이징 수행하여 화질 저하 방지

## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 
2. 
3. 


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.