### PR TITLE
refactor: 세션 모집 지원자 수 계산 로직 개선

### DIFF
--- a/BackendServer/src/application/application.service.ts
+++ b/BackendServer/src/application/application.service.ts
@@ -181,6 +181,11 @@ export class ApplicationService {
           );
         }
 
+        // ✅ 6.5 정원이 찼는지 확인
+        if (sessionEnsemble.nowRecruitCount >= sessionEnsemble.recruitCount) {
+          throw new ForbiddenException('해당 세션은 이미 모집이 완료되었습니다.');
+        }
+
         // 7. 새로운 지원자 생성 (여기서 관계형 엔티티를 직접 할당)
         const newApplier = transactionalEntityManager.create(ApplierEnsemble, {
           recruitEnsemble: recruitEnsemblePost, // 로드된 RecruitEnsemble 엔티티 객체를 직접 할당
@@ -191,14 +196,44 @@ export class ApplicationService {
 
         const savedApplier = await transactionalEntityManager.save(newApplier);
 
-        // 8. totalRecruitCnt 증가 (increment 메서드 사용)
-        // recruitEnsemblePost.totalRecruitCnt = (recruitEnsemblePost.totalRecruitCnt || 0) + 1;
-        // await transactionalEntityManager.save(recruitEnsemblePost); // 이 부분을 increment로 대체
+
+        // 8. nowRecruitCount를 증가시킴
         await transactionalEntityManager.increment(
-          RecruitEnsemble, // 업데이트할 엔티티 클래스
-          { postId: recruitEnsemblePost.postId }, // 업데이트할 레코드를 찾는 조건
-          'totalRecruitCnt', // 증가시킬 컬럼 이름
-          1, // 증가량
+          SessionEnsemble,
+          { sessionId: sessionEnsemble.sessionId },
+          'nowRecruitCount',
+          1,
+        );
+
+        // 8.5 증가 이후에 다시 조회해서 실제 최신 nowRecruitCount로 비교
+        const sessionEnsembleAfterUpdate = await transactionalEntityManager.findOne(
+          SessionEnsemble,
+          { where: { sessionId: sessionId } }
+        );
+
+        if (
+          !sessionEnsembleAfterUpdate ||
+          sessionEnsembleAfterUpdate.nowRecruitCount > sessionEnsembleAfterUpdate.recruitCount
+        ) {
+          throw new ForbiddenException('정원이 초과되었습니다.');
+        }
+
+        // 9. 세션 전체 조회 (같은 recruitEnsemble에 속한 것들)
+        const allSessions = await transactionalEntityManager.find(SessionEnsemble, {
+          where: { recruitEnsemble: { postId: recruitEnsemblePost.postId } },
+        });
+
+        const newTotalCount = allSessions.reduce((sum, session) => {
+          return sum + (session.sessionId === sessionEnsemble.sessionId
+            ? session.nowRecruitCount + 1 // 방금 증가시킨 세션은 +1 추가
+            : session.nowRecruitCount);
+        }, 0);
+
+        // 10. totalRecruitCnt를 해당 값으로 갱신
+        await transactionalEntityManager.update(
+          RecruitEnsemble,
+          { postId: recruitEnsemblePost.postId },
+          { totalRecruitCnt: newTotalCount },
         );
 
         const responseApplierDto = UserResponseDto.from(savedApplier.user);
@@ -246,7 +281,7 @@ export class ApplicationService {
           ApplierEnsemble,
           {
             where: { applicationId: applicationId },
-            relations: ['user'], // 사용자 정보가 필요하므로 relations 추가
+            relations: ['user', 'sessionEnsemble'], // 사용자 정보가 필요하므로 relations 추가
           },
         );
 
@@ -288,15 +323,41 @@ export class ApplicationService {
 
         // 6. totalRecruitCnt 감소 (decrement 메서드 사용)
         // totalRecruitCnt가 0보다 클 때만 감소하도록 조건을 추가합니다.
+        // if (
+        //   recruitEnsemblePost.totalRecruitCnt &&
+        //   recruitEnsemblePost.totalRecruitCnt > 0
+        // ) {
+        //   await transactionalEntityManager.decrement(
+        //     RecruitEnsemble, // 업데이트할 엔티티 클래스
+        //     { postId: recruitEnsemblePost.postId }, // 업데이트할 레코드를 찾는 조건
+        //     'totalRecruitCnt', // 감소시킬 컬럼 이름
+        //     1, // 감소량
+        //   );
+        // }
+
+        // 6. SessionEnsemble.nowRecruitCount 감소
+        if (
+          application.sessionEnsemble &&
+          application.sessionEnsemble.nowRecruitCount > 0
+        ) {
+          await transactionalEntityManager.decrement(
+            SessionEnsemble,
+            { sessionId: application.sessionEnsemble.sessionId },
+            'nowRecruitCount',
+            1,
+          );
+        }
+
+        // 7. totalRecruitCnt 감소 (최소 0 이상 유지)
         if (
           recruitEnsemblePost.totalRecruitCnt &&
           recruitEnsemblePost.totalRecruitCnt > 0
         ) {
           await transactionalEntityManager.decrement(
-            RecruitEnsemble, // 업데이트할 엔티티 클래스
-            { postId: recruitEnsemblePost.postId }, // 업데이트할 레코드를 찾는 조건
-            'totalRecruitCnt', // 감소시킬 컬럼 이름
-            1, // 감소량
+            RecruitEnsemble,
+            { postId: recruitEnsemblePost.postId },
+            'totalRecruitCnt',
+            1,
           );
         }
       },

--- a/BackendServer/src/ensemble/dto/pagination-query-recruit-ensemble.dto.ts
+++ b/BackendServer/src/ensemble/dto/pagination-query-recruit-ensemble.dto.ts
@@ -36,6 +36,6 @@ export class FilterRecruitEnsembleDto extends PaginationQueryRecruitEnsembleDto 
   skillLevel?: SKILL_LEVEL;
 
   @IsOptional()
-  @IsDate()
-  eventDate?: Date; 
+  @IsString()
+  eventDate?: string; 
 }

--- a/BackendServer/src/ensemble/ensemble.controller.ts
+++ b/BackendServer/src/ensemble/ensemble.controller.ts
@@ -34,9 +34,7 @@ export class EnsembleController {
     @Query() filter: FilterRecruitEnsembleDto,
   ): Promise<PaginatedRecruitEnsembleResponse> {
     this.logger.log('Fetching ensemble with pagination');
-
-    // const { limit = 20, lastPostId, lastCreatedAt } = paginationQuery;
-
+    
     return this.ensembleService.findEnsembleWithPagination(filter);
   }
 

--- a/BackendServer/src/ensemble/ensemble.service.ts
+++ b/BackendServer/src/ensemble/ensemble.service.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -428,7 +429,29 @@ export class EnsembleService {
         }
 
         // 3-2. 수정: 각 항목을 순회하며 업데이트
+        // for (const item of toUpdate) {
+        //   await queryRunner.manager.update(SessionEnsemble, item.sessionId, {
+        //     instrument: item.instrument,
+        //     recruitCount: item.recruitCount,
+        //   });
+        // }
+
+        // 3-2. 수정: 세션별 지원자 수보다 작은 recruitCount로 줄이는 것을 방지
         for (const item of toUpdate) {
+          const existingSession = await queryRunner.manager.findOne(SessionEnsemble, {
+            where: { sessionId: item.sessionId },
+          });
+
+          if (!existingSession) {
+            throw new NotFoundException(`Session ${item.sessionId} not found`);
+          }
+
+          if (item.recruitCount < existingSession.nowRecruitCount) {
+            throw new BadRequestException(
+              `"${item.instrument}"의 모집 인원은 지원자 수(${existingSession.nowRecruitCount}명) 보다 작게 설정할 수 없습니다.`,
+            );
+          }
+
           await queryRunner.manager.update(SessionEnsemble, item.sessionId, {
             instrument: item.instrument,
             recruitCount: item.recruitCount,

--- a/BackendServer/src/ensemble/entities/recruit-ensemble.entity.ts
+++ b/BackendServer/src/ensemble/entities/recruit-ensemble.entity.ts
@@ -54,7 +54,7 @@ export class RecruitEnsemble {
   @JoinColumn({ name: 'location' })
   location: Location;
 
-  @Column()
+  @Column({ default: 0 })
   totalRecruitCnt: number;
 
   @Column({ default: RECRUIT_STATUS.RECRUITING })

--- a/WebFrontend/src/components/layout/pages/ensemble/EnsembleCard.tsx
+++ b/WebFrontend/src/components/layout/pages/ensemble/EnsembleCard.tsx
@@ -33,6 +33,7 @@ const skillLevelColorMap: Record<number, string> = {
   3: "bg-yellow-500",
 };
 
+
 const EnsembleCard: React.FC<EnsembleCardProps> = ({ posts }) => {
   const navigate = useNavigate();
 
@@ -82,12 +83,15 @@ const EnsembleCard: React.FC<EnsembleCardProps> = ({ posts }) => {
             >
               {SKILL_LEVEL_DIC[post.skillLevel]}
             </p>
-            {post.sessionEnsemble.map((session) => (
-              <span key={session.sessionId} className="flex items-center justify-center gap-1 text-brand-gray">
-                <Icon name="user" size={15}/>
-                {session.nowRecruitCount}/{session.recruitCount}
-              </span>
-            ))}
+            {post.sessionEnsemble && post.sessionEnsemble.length > 0 && (
+              <div className="flex items-center gap-2 text-brand-gray">
+                <Icon name="user" size={15} />
+                <span>
+                  {post.sessionEnsemble.reduce((sum, s) => sum + s.nowRecruitCount, 0)}/
+                  {post.sessionEnsemble.reduce((sum, s) => sum + s.recruitCount, 0)}
+                </span>
+              </div>
+            )}
           </div>
         </article>
       ))}

--- a/WebFrontend/src/components/layout/pages/ensemble/EnsembleDetail.tsx
+++ b/WebFrontend/src/components/layout/pages/ensemble/EnsembleDetail.tsx
@@ -21,6 +21,7 @@ interface RecruitEnsembleProps {
   applicationEnsembleList: ApplicationEnsemble[];
   isApplied: boolean;
   totalUnreadCount?: number;
+  fetchApplicationList: () => Promise<void>;
 }
 
 const skillLevelColorMap: Record<number, string> = {
@@ -39,6 +40,7 @@ export const RecruitEnsembleDetail: React.FC<RecruitEnsembleProps> = ({
   applicationEnsembleList,
   isApplied,
   totalUnreadCount,
+  fetchApplicationList,
 }) => {
   return (
     <PostLayout totalUnreadCount={totalUnreadCount} bgClassName="bg-brand-inverse">
@@ -107,6 +109,7 @@ export const RecruitEnsembleDetail: React.FC<RecruitEnsembleProps> = ({
                 ensemble={post}
                 applicationEnsembleList={applicationEnsembleList}
                 isApplied={isApplied}
+                fetchApplicationList={fetchApplicationList}
               />
             ))
         }

--- a/WebFrontend/src/pages/ensemble/CreateRecruitEnsemblePage.tsx
+++ b/WebFrontend/src/pages/ensemble/CreateRecruitEnsemblePage.tsx
@@ -49,7 +49,7 @@ const CreateRecruitEnsemblePage: React.FC = () => {
     eventDate: new Date().toISOString().split('T')[0],
     skillLevel: SKILL_LEVEL.BEGINNER,
     locationId: '',
-    totalRecruitCnt: '1',
+    totalRecruitCnt: '',
     sessionEnsemble: sessionFormList,
   });
 

--- a/WebFrontend/src/pages/ensemble/RecruitEnsembleDetailPage.tsx
+++ b/WebFrontend/src/pages/ensemble/RecruitEnsembleDetailPage.tsx
@@ -27,6 +27,7 @@ const RecruitEnsembleDetailPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isApplied, setIsApplied] = useState(false);
 
+
   // 현재 로그인한 사용자가 게시글 작성자인지 확인하는 변수
   const isOwner = Boolean(ensemble && user && ensemble.user.id === user.id);
   console.log('ensemble check ',isOwner, ensemble, user);
@@ -90,6 +91,17 @@ const RecruitEnsembleDetailPage: React.FC = () => {
     }
   }, [applicationList, user])
 
+  const fetchApplicationList = async () => {
+    if (!ensemble) return;
+    try {
+      const response = await axiosInstance.get<ApplicationEnsemble[]>(`application/${ensemble.postId}`);
+      setApplicationList(response.data);
+    } catch (err) {
+      setError('지원자 정보를 갱신하는 데 실패했습니다.');
+    }
+  };
+
+
   const handleEdit = () => {
     navigate(`/ensembles/edit/${id}`);
   };
@@ -143,6 +155,7 @@ const RecruitEnsembleDetailPage: React.FC = () => {
       onDelete={handleDelete}
       applicationEnsembleList={applicationList || []}
       isApplied={isApplied}
+      fetchApplicationList={fetchApplicationList}
     />
   );
 };

--- a/WebFrontend/src/pages/ensemble/UpdateRecruitEnsemblePage.tsx
+++ b/WebFrontend/src/pages/ensemble/UpdateRecruitEnsemblePage.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import axiosInstance from '@/services/axiosInstance';
+import axios from 'axios';
 import { useAuthStore } from '@/stores/authStore';
 import { useChatStore } from '../../stores/chatStore';
 import { EnsembleForm, type RecruitEnsembleFormState } from '@/pages/ensemble/components/EnsembleForm';
@@ -45,7 +46,7 @@ const UpdateRecruitEnsemblePage: React.FC = () => {
     eventDate: '',
     skillLevel: SKILL_LEVEL.BEGINNER,
     locationId: '',
-    totalRecruitCnt: '1',
+    totalRecruitCnt: '',
     sessionEnsemble: sessionFormList,
   });
 
@@ -163,8 +164,19 @@ const UpdateRecruitEnsemblePage: React.FC = () => {
       navigate(`/ensembles/${id}`);
 
     } catch (err) {
-      setError('수정 중 오류가 발생했습니다.');
-      console.error(err);
+      if (axios.isAxiosError(err)){
+        const rawMessage = err.response?.data?.message;
+        console.log(err.response?.data);
+        const finalMessage = Array.isArray(rawMessage)
+          ? rawMessage.join('\n')
+          : typeof rawMessage === 'string'
+            ? rawMessage
+            : '알 수 없는 오류입니다.';
+
+        setError(finalMessage);
+      }else {
+        setError('예기치 못한 오류가 발생했습니다.');
+      }
     } finally {
       setLoading(false);
     }

--- a/WebFrontend/src/pages/ensemble/components/SessionDetail.tsx
+++ b/WebFrontend/src/pages/ensemble/components/SessionDetail.tsx
@@ -17,6 +17,7 @@ interface SessionDetailProps {
   ensemble: RecruitEnsemble;
   applicationEnsembleList: ApplicationEnsemble[];
   isApplied: boolean;
+  fetchApplicationList: () => Promise<void>;
 }
 
 export const SessionDetail: React.FC<SessionDetailProps> = ({
@@ -24,6 +25,7 @@ export const SessionDetail: React.FC<SessionDetailProps> = ({
   ensemble,
   applicationEnsembleList,
   isApplied,
+  fetchApplicationList,
 }) => {
   const { user } = useAuthStore();
   const [, setError] = useState<string | null>(null);
@@ -55,9 +57,15 @@ export const SessionDetail: React.FC<SessionDetailProps> = ({
         `application/${ensemble.postId}/${item.sessionId}`
       );
       alert("모집 공고에 지원했습니다!");
+      await fetchApplicationList();
     } catch (err) {
       if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
         const messages = err.response?.data?.message;
+        if (status === 403) {
+          alert("이미 모집이 마감되었거나 지원이 불가능한 세션입니다.");
+          return;
+        }
         setError(
           Array.isArray(messages)
             ? messages.join("\n")
@@ -82,6 +90,7 @@ export const SessionDetail: React.FC<SessionDetailProps> = ({
         `application/${ensemble.postId}/${item.sessionId}/${application?.applicationId}`
       );
       alert("모집 공고 지원을 취소했습니다!");
+      await fetchApplicationList();
     } catch (err) {
       if (axios.isAxiosError(err)) {
         const messages = err.response?.data?.message;


### PR DESCRIPTION
## 📜 PR 개요
## 💻 작업 내용

### ✅ 주요 변경사항

- [x] 세션 단위 지원 인원 처리 로직 개선
  - **기존:** 
  - 지원 시 RecruitEnsemble.totalRecruitCnt만 증가하고, 
  - 각 SessionEnsemble.nowRecruitCount는 갱신되지 않아 모집 정원 초과 지원이 가능했음
  - **변경:**
  - SessionEnsemble.nowRecruitCount를 먼저 증가시키고,
  - 이후 RecruitEnsemble.totalRecruitCnt는 모든 세션의 nowRecruitCount 합산값으로 동기화됨
  - 세션 단위 정원 초과 방지 및 테이블 간 데이터 불일치 문제 해결
- [x] 지원 성공 시 화면 즉시 반영
  - 지원 요청(POST /application/...) 이후, GET /application/{postId} 요청으로 갱신된 데이터를 받아와 상태를 업데이트
  - 기존에는 새로고침을 해야만 반영되던 문제 해결
- [x] 지원자 수보다 적은 모집 인원으로 수정 불가하도록 검증 추가
  - 기존에는 지원자 수를 고려하지 않고 세션 모집 인원 변경이 가능함
  - 현재는 각 세션 단위로 현재 지원자 수보다 작은 모집 인원으로 변경 시, 400 Bad Request 에러를 반환하며 수정이 차단됨
  - 기존 지원자가 존재하는 상태에서 모집 인원을 줄여 데이터 불일치가 발생하는 문제를 사전에 방지
- [x] 세션별 인원이 아닌 총 모집 현황 표시
  - 카드 혹은 목록에서 개별 세션 인원 표시 대신, 전체 세션을 합산한 모집 현황(총 지원자 수 / 총 모집 인원) 표시로 UX 개선

### 🛠 기타
  - 에러 핸들링 개선 (403, 400 등 상태에 따른 메시지 분기)

## 🔗 관련 이슈
Closes #


## ✓ 테스트 방법
1. 정원이 초과된 세션에 지원하여, 에러 메세지 확인
2. 정원보다 적은 수로 세션 인원 변경 시도 후 에러 메세지 확인
3. 기타 세션 관련하여 폼 제출이 잘 되는지 확인


## 🖼️ 스크린샷 (선택 사항)
## ❗ 리뷰어에게 전달할 특이사항
## ✅ PR 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했습니다.
- [ ] 코딩 컨벤션을 준수했습니다.
- [ ] 불필요한 주석이나 디버깅 코드를 삭제했습니다.
- [ ] 관련 테스트 코드를 추가/수정했습니다. (해당하는 경우)
- [ ] 빌드 및 테스트가 로컬에서 성공적으로 통과했습니다.